### PR TITLE
fix: configure Electron main for ts-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "etiketten",
   "version": "0.1.0",
   "private": true,
-  "main": "dist/main/main.js",
+  "main": "src/main/main.ts",
   "type": "module",
   "scripts": {
     "dev": "concurrently -k -n MAIN,RENDERER \"npm:dev:main\" \"npm:dev:renderer\"",
-    "dev:main": "ts-node --project tsconfig.json src/main/main.ts",
+    "dev:main": "cross-env NODE_OPTIONS=\"-r ts-node/register/transpile-only -r source-map-support/register\" TS_NODE_PROJECT=tsconfig.json electron .",
     "dev:renderer": "vite --config vite.config.ts",
     "build": "npm run build:renderer && tsc -p tsconfig.json",
     "build:renderer": "vite build --config vite.config.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,15 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ESNext",
+    "module": "CommonJS",
     "outDir": "dist",
     "rootDir": "src",
-    "moduleResolution": "node",
+    "moduleResolution": "Node",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "sourceMap": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/main/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- configure main process tsconfig for CommonJS and Node resolution
- run Electron main via ts-node register hooks and source-map support

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a44eb173d883259062abf967c80686