### PR TITLE
Use dev bootstrap for Electron main process

### DIFF
--- a/dev-main.cjs
+++ b/dev-main.cjs
@@ -1,0 +1,7 @@
+// dev-main.cjs – Bootstrap für Electron im DEV
+process.env.TS_NODE_PROJECT = process.env.TS_NODE_PROJECT || 'tsconfig.main.json';
+require('ts-node/register/transpile-only');
+require('source-map-support/register');
+
+// Jetzt das eigentliche Electron-Main laden (CJS require, ts-node hooked)
+require('./src/main/main.ts');

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "npm run build:preload && concurrently -k \"npm:dev:renderer\" \"npm:dev:main\"",
     "dev:renderer": "vite --config vite.config.mts",
-    "dev:main": "wait-on http://localhost:5173 && cross-env TS_NODE_PROJECT=tsconfig.json TS_NODE_COMPILER_OPTIONS={\"module\":\"CommonJS\"} NODE_OPTIONS=\"--require ts-node/register/transpile-only --require source-map-support/register\" electron .",
+    "dev:main": "wait-on http://localhost:5173 && electron ./dev-main.cjs",
     "build:preload": "tsc src/preload.ts --outDir build --module commonjs --target ES2020 --esModuleInterop",
     "build:renderer": "vite build",
     "start": "electron .",


### PR DESCRIPTION
## Summary
- add `dev-main.cjs` bootstrap for running main process through ts-node during development
- simplify `dev:main` script to launch Electron via new bootstrap file

## Testing
- `npm test`
- `npm run build:preload`


------
https://chatgpt.com/codex/tasks/task_e_68a5b12e0f1c83259c3f1e0a428d8986