### PR TITLE
feat: improve datanorm import handling

### DIFF
--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -1,6 +1,4 @@
-import { ipcMain, dialog } from 'electron';
-import fs from 'fs/promises';
-import os from 'os';
+import { ipcMain } from 'electron';
 import path from 'path';
 import { importDatanorm } from '../datanorm/parser';
 import { registerArticlesHandlers } from './articles';
@@ -8,53 +6,37 @@ import { registerCartHandlers } from './cart';
 import { registerLabelsHandlers } from './labels';
 import { registerShellHandlers } from './shell';
 
-let lastSelectedPath: string | undefined;
-
 export function registerIpcHandlers() {
   registerArticlesHandlers();
   registerCartHandlers();
   registerLabelsHandlers();
   registerShellHandlers();
 
-  ipcMain.handle('datanorm:openDialog', async () => {
+  type DatanormImportPayload = {
+    filePath: string; // absoluter Pfad zur DATANORM.001
+    name?: string; // optional; default = basename(filePath)
+    mapping?: {
+      articleNumber?: boolean;
+      ean?: boolean;
+      shortText?: boolean;
+      price?: boolean;
+      image?: boolean;
+    };
+  };
+
+  ipcMain.handle('datanorm:import', async (evt, raw: DatanormImportPayload) => {
+    if (!raw || !raw.filePath) {
+      throw new RangeError('Missing required parameter "filePath"');
+    }
+    const filePath = raw.filePath;
+    const safeName = (raw.name && raw.name.trim()) || path.basename(filePath);
+    const mapping = raw.mapping ?? {};
     try {
-      const res = await dialog.showOpenDialog({
-        properties: ['openFile'],
-        filters: [{ name: 'DATANORM 4/5', extensions: ['001', 'dat', 'txt'] }],
-      });
-      if (!res.canceled && res.filePaths.length > 0) {
-        lastSelectedPath = res.filePaths[0];
-      } else {
-        lastSelectedPath = undefined;
-      }
+      const imported = await importDatanorm(filePath, evt.sender);
+      return { imported, name: safeName, path: filePath, mapping };
     } catch (err) {
-      console.error('openDialog failed', err);
+      console.error('import failed', err);
       throw err;
     }
   });
-
-  ipcMain.handle(
-    'datanorm:import',
-    async (event, args: { useDialog?: boolean; fileBuffer?: ArrayBuffer }) => {
-      try {
-        let filePath: string | undefined;
-        if (args?.useDialog) {
-          filePath = lastSelectedPath;
-        }
-        if (args?.fileBuffer) {
-          const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'datanorm-'));
-          filePath = path.join(tmpDir, 'import.dat');
-          await fs.writeFile(filePath, Buffer.from(args.fileBuffer));
-        }
-        if (!filePath) {
-          throw new Error('No file selected');
-        }
-        const imported = await importDatanorm(filePath, event.sender);
-        return { imported };
-      } catch (err) {
-        console.error('import failed', err);
-        throw err;
-      }
-    },
-  );
 }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,29 +1,21 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
+export type DatanormImportPayload = {
+  filePath: string;
+  name?: string;
+  mapping?: {
+    articleNumber?: boolean;
+    ean?: boolean;
+    shortText?: boolean;
+    price?: boolean;
+    image?: boolean;
+  };
+};
+
 const bridge = {
   ready: true,
-  dialog: {
-    openDatanorm: async (): Promise<void> => {
-      try {
-        await ipcRenderer.invoke('datanorm:openDialog');
-      } catch (err) {
-        console.error('openDatanorm failed', err);
-        throw err;
-      }
-    },
-  },
-  importDatanorm: async (opts: { fileBuffer?: ArrayBuffer; useDialog?: boolean }): Promise<{ imported: number }> => {
-    try {
-      if (opts?.useDialog) {
-        await ipcRenderer.invoke('datanorm:openDialog');
-        return await ipcRenderer.invoke('datanorm:import', { useDialog: true });
-      }
-      return await ipcRenderer.invoke('datanorm:import', opts);
-    } catch (err) {
-      console.error('importDatanorm failed', err);
-      throw err;
-    }
-  },
+  importDatanorm: (payload: DatanormImportPayload) =>
+    ipcRenderer.invoke('datanorm:import', payload),
   onImportProgress: (
     cb: (p: { phase: string; current: number; total?: number }) => void,
   ): (() => void) => {

--- a/src/renderer/components/ImportPane.tsx
+++ b/src/renderer/components/ImportPane.tsx
@@ -1,8 +1,15 @@
 import React, { useEffect, useState } from 'react';
-import { Button } from '@fluentui/react-components';
+import { Button, Checkbox } from '@fluentui/react-components';
 
 const ImportPane: React.FC = () => {
-  const [file, setFile] = useState<File | null>(null);
+  const [selectedFile, setSelectedFile] = useState<{ filePath: string; name: string } | null>(null);
+  const [flags, setFlags] = useState({
+    articleNumber: true,
+    ean: true,
+    shortText: true,
+    price: true,
+    image: true,
+  });
   const [progress, setProgress] = useState<{ phase: string; current: number; total?: number } | undefined>();
   const [isImporting, setIsImporting] = useState(false);
   const [imported, setImported] = useState<number | null>(null);
@@ -12,31 +19,60 @@ const ImportPane: React.FC = () => {
     return () => off?.();
   }, []);
 
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const f = e.target.files?.[0] || null;
-    setFile(f);
+  const onFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    setSelectedFile({
+      filePath: (f as any).path ?? '',
+      name: f.name,
+    });
   };
 
+  const toggle = (key: keyof typeof flags) => (_: any, data: any) =>
+    setFlags((prev) => ({ ...prev, [key]: !!data.checked }));
+
   const handleImport = async () => {
-    if (!window.bridge?.importDatanorm || !file) return;
+    if (!window.bridge?.importDatanorm) return;
+    if (!selectedFile?.filePath) {
+      alert('Kein Dateipfad vorhanden. Bitte Datei neu auswählen.');
+      return;
+    }
     setIsImporting(true);
     setProgress(undefined);
     setImported(null);
     try {
-      const buffer = await file.arrayBuffer();
-      const res = await window.bridge.importDatanorm({ fileBuffer: buffer });
-      setImported(res.imported);
+      const res = await window.bridge.importDatanorm({
+        filePath: selectedFile.filePath,
+        name: selectedFile.name,
+        mapping: {
+          articleNumber: flags.articleNumber,
+          ean: flags.ean,
+          shortText: flags.shortText,
+          price: flags.price,
+          image: flags.image,
+        },
+      });
+      if (res?.imported !== undefined) setImported(res.imported);
+    } catch (err) {
+      console.error('importDatanorm failed', err);
     } finally {
       setIsImporting(false);
     }
   };
-  const disabled = !window.bridge?.ready || !file || isImporting;
+  const disabled = !window.bridge?.ready || !selectedFile?.filePath || isImporting;
   const pct = progress?.total ? Math.round((progress.current / progress.total) * 100) : undefined;
 
   return (
     <div>
-      <input type="file" accept=".001,.dat,.txt,.zip" onChange={handleFileChange} />
-      {file && <div>{file.name}</div>}
+      <input type="file" accept=".001,.dat,.txt,.zip" onChange={onFileChange} />
+      {selectedFile?.name && <div>{selectedFile.name}</div>}
+      <div>
+        <Checkbox label="Artikelnummer" checked={flags.articleNumber} onChange={toggle('articleNumber')} />
+        <Checkbox label="EAN" checked={flags.ean} onChange={toggle('ean')} />
+        <Checkbox label="Kurztext" checked={flags.shortText} onChange={toggle('shortText')} />
+        <Checkbox label="Preis" checked={flags.price} onChange={toggle('price')} />
+        <Checkbox label="Bild" checked={flags.image} onChange={toggle('image')} />
+      </div>
       <Button onClick={handleImport} disabled={disabled}>
         {isImporting ? 'Importiere…' : 'Importieren'}
       </Button>

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -2,8 +2,17 @@ declare global {
   interface Window {
     bridge?: {
       ready: boolean;
-      dialog?: { openDatanorm: () => Promise<void> };
-      importDatanorm?: (opts: { fileBuffer?: ArrayBuffer }) => Promise<{ imported: number }>;
+      importDatanorm?: (payload: {
+        filePath: string;
+        name?: string;
+        mapping?: {
+          articleNumber?: boolean;
+          ean?: boolean;
+          shortText?: boolean;
+          price?: boolean;
+          image?: boolean;
+        };
+      }) => Promise<any>;
       onImportProgress?: (
         cb: (p: { phase: string; current: number; total?: number }) => void,
       ) => () => void;


### PR DESCRIPTION
## Summary
- make `datanorm:import` require filePath and derive missing name
- expose strict import payload via preload bridge
- send file path and optional mapping from ImportPane

## Testing
- `npm test`
- `npm run build:preload`
- `npm run build:renderer`


------
https://chatgpt.com/codex/tasks/task_e_68a5b944c4ac83259ae5426d8c6f29d7