### PR TITLE
Fix better-sqlite3 typings and add typecheck script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "dist": "npm run build:renderer && electron-builder",
     "rebuild-native": "electron-rebuild -f -w better-sqlite3 -w sharp",
     "postinstall": "electron-builder install-app-deps",
-    "test": "echo \"No tests configured\" && exit 0"
+    "test": "echo \"No tests configured\" && exit 0",
+    "typecheck": "tsc -p tsconfig.main.json --noEmit"
   },
   "dependencies": {
     "electron": "^30.0.0",

--- a/src/main/ipc/articles.ts
+++ b/src/main/ipc/articles.ts
@@ -5,7 +5,11 @@ import { IPC_CHANNELS, SearchPayloadSchema, SearchResultSchema } from '../../sha
 export function registerArticlesHandlers() {
   ipcMain.handle(IPC_CHANNELS.articles.search, (_e, payload) => {
     const { query, page, pageSize } = SearchPayloadSchema.parse(payload);
-    const items = searchArticles(query, pageSize, page * pageSize);
-    return SearchResultSchema.parse({ items, total: items.length });
+    const { items, total } = searchArticles({
+      text: query,
+      limit: pageSize,
+      offset: page * pageSize,
+    });
+    return SearchResultSchema.parse({ items, total });
   });
 }

--- a/src/main/ipc/cart.ts
+++ b/src/main/ipc/cart.ts
@@ -8,7 +8,7 @@ export function registerCartHandlers() {
 
   ipcMain.handle(IPC_CHANNELS.cart.add, (_e, payload) => {
     const { articleId, qty, opts } = CartAddSchema.parse(payload);
-    return addToCart(articleId, qty, opts);
+    return addToCart(Number(articleId), qty, opts);
   });
 
   ipcMain.handle(IPC_CHANNELS.cart.update, (_e, payload) => {

--- a/src/types/better-sqlite3.d.ts
+++ b/src/types/better-sqlite3.d.ts
@@ -1,1 +1,6 @@
-declare module 'better-sqlite3';
+declare module 'better-sqlite3' {
+  export default class Database {
+    constructor(...args: any[]);
+    [key: string]: any;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "types": ["node"]
   },
     "include": ["src/main/**/*.ts", "src/preload.ts", "src/renderer/**/*.d.ts", "src/types/**/*.d.ts"]
   }

--- a/tsconfig.main.json
+++ b/tsconfig.main.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "types": ["node"]
+  }
+}


### PR DESCRIPTION
## Summary
- Define better-sqlite3 default export to avoid namespace type errors
- Fix IPC handlers for articles and cart to use db APIs correctly
- Harden TS configs with Node types and skipLibCheck, add dedicated main tsconfig and typecheck script

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run typecheck`
- `npm test`
- `npm run dev` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a62fed3dfc8325b141da8dad2f43f5