### PR TITLE
feat: add DATANORM importer

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.spec.ts']
+};

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dist": "npm run build:renderer && electron-builder",
     "rebuild-native": "electron-rebuild -f -w better-sqlite3 -w sharp",
     "postinstall": "electron-builder install-app-deps",
-    "test": "echo \"No tests configured\" && exit 0",
+    "test": "jest",
     "typecheck": "tsc -p tsconfig.main.json --noEmit"
   },
   "dependencies": {
@@ -52,7 +52,10 @@
     "@types/pdfkit": "^0.13.5",
     "@types/bwip-js": "^2.0.0",
     "@types/adm-zip": "^0.5.0",
-    "@vitejs/plugin-react": "^5.0.0"
+    "@vitejs/plugin-react": "^5.0.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.4"
   },
   "build": {
     "appId": "com.cloudia.etiketten",

--- a/src/cli/datanorm-import.ts
+++ b/src/cli/datanorm-import.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+import { importDatanorm } from '../datanorm';
+
+function getArg(name: string): string | undefined {
+  const idx = process.argv.indexOf(`--${name}`);
+  if (idx >= 0) return process.argv[idx + 1];
+  return undefined;
+}
+
+async function main() {
+  const input = getArg('input');
+  if (!input) {
+    console.error('usage: datanorm-import --input <path> [--supplier "Name"] [--version auto|v4|v5]');
+    process.exit(1);
+  }
+  const supplier = getArg('supplier');
+  const version = (getArg('version') as any) || 'auto';
+  const dry = getArg('dry-run') === 'true';
+  const result = await importDatanorm({ input, supplierName: supplier, version, dryRun: dry });
+  console.log('Import finished', result);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/datanorm/encoding.ts
+++ b/src/datanorm/encoding.ts
@@ -1,0 +1,12 @@
+import { Readable } from 'stream';
+import iconv from 'iconv-lite';
+
+/**
+ * Wrap a readable stream and decode CP850 encoded bytes to UTF-8 strings.
+ * Many DATANORM sources use CP850. This helper ensures we always work with
+ * UTF-8 strings internally.
+ */
+export function decodeCp850(stream: Readable): Readable {
+  const decoder = iconv.decodeStream('cp850');
+  return stream.pipe(decoder);
+}

--- a/src/datanorm/importer.ts
+++ b/src/datanorm/importer.ts
@@ -1,0 +1,217 @@
+import fs from 'fs';
+import path from 'path';
+import readline from 'readline';
+import { decodeCp850 } from './encoding';
+import { resolveInputFiles, InputFile } from './io';
+import { parseV4Line } from './parsers/v4';
+import { parseV5Line } from './parsers/v5';
+import {
+  AnyRecord,
+  ArticleRecord,
+  ArticleAddRecord,
+  TextRecord,
+  PriceRecord,
+  PriceTierRecord,
+  WarengruppeRecord,
+  RabattgruppeRecord,
+  MediaRecord,
+} from './records';
+import { validateArticle, validatePrice } from './validator';
+import {
+  getDb,
+  upsertArticle,
+  upsertWarengruppe,
+  upsertRabattgruppe,
+  setArticleText,
+  insertPrice,
+  insertPriceTier,
+  insertMedia,
+} from '../db';
+import type { DatanormImportOptions, ImportResult } from './index';
+
+interface ProcessState {
+  articleTexts: Record<string, string[]>;
+  lastPriceId: Record<string, number>;
+}
+
+function detectVersion(line: string): 'v4' | 'v5' {
+  return line.includes(';') ? 'v5' : 'v4';
+}
+
+async function processFile(
+  file: InputFile,
+  version: 'v4' | 'v5',
+  opts: DatanormImportOptions,
+  state: ProcessState,
+  counts: any,
+  errors: any[]
+): Promise<{ lines: number; errors: number }> {
+  const db = getDb();
+  const rl = readline.createInterface({
+    input: decodeCp850(fs.createReadStream(file.path)),
+    crlfDelay: Infinity,
+  });
+  let lineNo = 0;
+  let ok = 0;
+  let err = 0;
+  let skipped = 0;
+  const parsed: AnyRecord[] = [];
+  for await (const line of rl) {
+    lineNo++;
+    if (!line.trim()) continue;
+    const rec = version === 'v5' ? parseV5Line(line) : parseV4Line(line);
+    if (!rec) continue;
+    try {
+      switch (rec.type) {
+        case 'S': {
+          const r = rec as WarengruppeRecord;
+          const id = upsertWarengruppe({
+            hauptgruppe: r.hauptgruppe,
+            gruppe: r.gruppe,
+            bezeichnung: r.bezeichnung,
+          });
+          (counts.warengruppen += 1);
+          break;
+        }
+        case 'R': {
+          const r = rec as RabattgruppeRecord;
+          upsertRabattgruppe({ nummer: r.nummer, bezeichnung: r.bezeichnung });
+          counts.rabattgruppen += 1;
+          break;
+        }
+        case 'A': {
+          const r = rec as ArticleRecord;
+          const val = validateArticle(r, version);
+          if (val.length) throw new Error(val.map((v) => `${v.field}:${v.message}`).join(','));
+          const articleId = upsertArticle({
+            ...r,
+            warengruppe_id: undefined,
+            rabattgruppe_id: undefined,
+          });
+          counts.articles += 1;
+          break;
+        }
+        case 'B': {
+          const r = rec as ArticleAddRecord;
+          const articleId = upsertArticle({
+            type: 'A',
+            artnr: r.artnr,
+            kurztext1: '',
+            kurztext2: '',
+            einheit: '',
+            katalogseite: r.katalogseite,
+            steuer_merker: r.steuer_merker,
+          } as any);
+          break;
+        }
+        case 'T': {
+          const r = rec as TextRecord;
+          if (!state.articleTexts[r.artnr]) state.articleTexts[r.artnr] = [];
+          state.articleTexts[r.artnr].push(r.text);
+          break;
+        }
+        case 'P': {
+          const r = rec as PriceRecord;
+          const val = validatePrice(r, version);
+          if (val.length) throw new Error(val.map((v) => `${v.field}:${v.message}`).join(','));
+          const art = db.prepare('SELECT id FROM articles WHERE artnr=?').get(r.artnr);
+          if (art) {
+            const cents = Math.round(parseFloat(r.betrag.replace(',', '.')) * 100);
+            const priceId = insertPrice({
+              article_id: art.id,
+              typ: r.kennzeichen === '1' ? 'BRUTTO' : 'NETTO',
+              betrag_cent: cents,
+              einheit: r.einheit,
+              gueltig_ab: r.gueltig_ab,
+              gueltig_bis: r.gueltig_bis,
+              kundennr: r.kundennr,
+            });
+            state.lastPriceId[r.artnr] = priceId;
+            counts.prices += 1;
+          }
+          break;
+        }
+        case 'Z': {
+          const r = rec as PriceTierRecord;
+          const priceId = state.lastPriceId[r.artnr];
+          if (priceId) {
+            const cents = Math.round(parseFloat(r.aufabschlag.replace(',', '.')) * 100);
+            insertPriceTier({ price_id: priceId, von_menge: r.von_menge, zu_abaufschlag_cent: cents });
+            counts.priceTiers += 1;
+          }
+          break;
+        }
+        case 'G': {
+          const r = rec as MediaRecord;
+          const art = db.prepare('SELECT id FROM articles WHERE artnr=?').get(r.artnr);
+          if (art) {
+            insertMedia({ article_id: art.id, art: r.art, dateiname: r.dateiname, beschreibung: r.beschreibung });
+            counts.media += 1;
+          }
+          break;
+        }
+        case 'E':
+          break;
+        default:
+          skipped++;
+      }
+      ok++;
+    } catch (e: any) {
+      err++;
+      errors.push({ file: file.name, line: lineNo, error: e.message });
+    }
+    opts.onProgress?.({ file: file.name, line: lineNo, ok, skipped, errors: err });
+  }
+  // flush texts
+  for (const artnr of Object.keys(state.articleTexts)) {
+    const art = db.prepare('SELECT id FROM articles WHERE artnr=?').get(artnr);
+    if (art) {
+      setArticleText(art.id, state.articleTexts[artnr].join('\n'));
+      counts.texts += 1;
+    }
+  }
+  return { lines: lineNo, errors: err };
+}
+
+export async function runImport(opts: DatanormImportOptions): Promise<ImportResult> {
+  const files = await resolveInputFiles(opts.input);
+  const counts = {
+    articles: 0,
+    texts: 0,
+    warengruppen: 0,
+    rabattgruppen: 0,
+    prices: 0,
+    priceTiers: 0,
+    media: 0,
+    sets: 0,
+    errors: 0,
+  };
+  const errors: any[] = [];
+  let version: 'v4' | 'v5' | null = null;
+  const db = getDb();
+  for (const f of files) {
+    const firstLine = fs.readFileSync(f.path, { encoding: 'utf8' }).split(/\r?\n/)[0];
+    const v = opts.version && opts.version !== 'auto' ? opts.version : detectVersion(firstLine);
+    if (!version) version = v;
+    const state: ProcessState = { articleTexts: {}, lastPriceId: {} };
+    db.exec('BEGIN');
+    const result = await processFile(f, v as 'v4' | 'v5', opts, state, counts, errors);
+    const ratio = result.lines ? result.errors / result.lines : 0;
+    if (opts.dryRun || ratio > 0.05) {
+      db.exec('ROLLBACK');
+    } else {
+      db.exec('COMMIT');
+    }
+  }
+  counts.errors = errors.length;
+  const reportDir = path.join(process.cwd(), '.datanorm');
+  fs.mkdirSync(reportDir, { recursive: true });
+  const reportPath = path.join(reportDir, `import-report-${Date.now()}.json`);
+  fs.writeFileSync(reportPath, JSON.stringify({ errors }, null, 2), 'utf8');
+  return {
+    version: version || 'v5',
+    filesProcessed: files.map((f) => f.name),
+    counts,
+    reportPath,
+  };
+}

--- a/src/datanorm/index.ts
+++ b/src/datanorm/index.ts
@@ -1,0 +1,31 @@
+import { runImport } from './importer';
+
+export interface DatanormImportOptions {
+  input: string;
+  supplierName?: string;
+  dryRun?: boolean;
+  onProgress?: (info: { file: string; line: number; ok: number; skipped: number; errors: number }) => void;
+  version?: 'v4' | 'v5' | 'auto';
+}
+
+export interface ImportResult {
+  version: 'v4' | 'v5';
+  filesProcessed: string[];
+  counts: {
+    articles: number;
+    texts: number;
+    warengruppen: number;
+    rabattgruppen: number;
+    prices: number;
+    priceTiers: number;
+    media: number;
+    sets: number;
+    errors: number;
+  };
+  reportPath: string;
+}
+
+export async function importDatanorm(opts: DatanormImportOptions): Promise<ImportResult> {
+  const options = { version: 'auto', dryRun: false, ...opts } as DatanormImportOptions;
+  return runImport(options);
+}

--- a/src/datanorm/io.ts
+++ b/src/datanorm/io.ts
@@ -1,0 +1,31 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import AdmZip from 'adm-zip';
+
+export interface InputFile {
+  name: string; // original file name
+  path: string; // absolute path
+}
+
+/**
+ * Resolve DATANORM files from a directory or a ZIP archive. All relevant
+ * files are returned in the order they should be processed.
+ */
+export async function resolveInputFiles(input: string): Promise<InputFile[]> {
+  const stat = fs.statSync(input);
+  let dir = input;
+  if (stat.isFile()) {
+    // assume zip
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'datanorm-'));
+    const zip = new AdmZip(input);
+    zip.extractAllTo(tmp, true);
+    dir = tmp;
+  }
+  const files = fs
+    .readdirSync(dir)
+    .filter((f) => /^DAT(A|P)\w+/.test(f))
+    .map((f) => ({ name: f, path: path.join(dir, f) }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+  return files;
+}

--- a/src/datanorm/parsers/v4.ts
+++ b/src/datanorm/parsers/v4.ts
@@ -1,0 +1,64 @@
+import { AnyRecord } from '../records';
+
+function slice(line: string, start: number, length: number): string {
+  return line.substring(start - 1, start - 1 + length).trim();
+}
+
+export function parseV4Line(line: string): AnyRecord | null {
+  const type = line[0];
+  switch (type) {
+    case 'V':
+      return { type: 'V' } as AnyRecord;
+    case 'S':
+      return {
+        type: 'S',
+        hauptgruppe: slice(line, 2, 3),
+        gruppe: slice(line, 5, 10),
+        bezeichnung: slice(line, 15, 40),
+      };
+    case 'R':
+      return { type: 'R', nummer: slice(line, 2, 4), bezeichnung: slice(line, 6, 40) };
+    case 'A':
+      return {
+        type: 'A',
+        artnr: slice(line, 2, 15),
+        kurztext1: slice(line, 17, 40),
+        kurztext2: slice(line, 57, 40),
+        einheit: slice(line, 97, 4),
+        ean: slice(line, 101, 13),
+        matchcode: slice(line, 114, 15),
+        warengruppe: slice(line, 129, 10),
+        rabattgruppe: slice(line, 139, 4),
+      };
+    case 'B':
+      return {
+        type: 'B',
+        artnr: slice(line, 2, 15),
+        katalogseite: slice(line, 17, 5),
+        steuer_merker: slice(line, 22, 1),
+      };
+    case 'T':
+      return { type: 'T', artnr: slice(line, 2, 15), text: slice(line, 17, 40) };
+    case 'P':
+      return {
+        type: 'P',
+        artnr: slice(line, 2, 15),
+        kennzeichen: slice(line, 17, 1) as '1' | '2',
+        betrag: slice(line, 18, 8),
+        einheit: slice(line, 26, 4),
+        gueltig_ab: slice(line, 30, 8),
+        gueltig_bis: slice(line, 38, 8),
+      };
+    case 'Z':
+      return {
+        type: 'Z',
+        artnr: slice(line, 2, 15),
+        von_menge: slice(line, 17, 5),
+        aufabschlag: slice(line, 22, 6),
+      };
+    case 'E':
+      return { type: 'E' } as AnyRecord;
+    default:
+      return null;
+  }
+}

--- a/src/datanorm/parsers/v5.ts
+++ b/src/datanorm/parsers/v5.ts
@@ -1,0 +1,54 @@
+import { AnyRecord } from '../records';
+
+export function parseV5Line(line: string): AnyRecord | null {
+  const cols = line
+    .split(';')
+    .map((c) => c.replace(/^"|"$/g, ''))
+    .map((c) => c.trim());
+  const type = cols[0];
+  switch (type) {
+    case 'V':
+      return { type: 'V', creator: cols[1], currency: cols[2], date: cols[3] } as AnyRecord;
+    case 'S':
+      return { type: 'S', hauptgruppe: cols[1], gruppe: cols[2], bezeichnung: cols[3] };
+    case 'R':
+      return { type: 'R', nummer: cols[1], bezeichnung: cols[2] };
+    case 'A':
+      return {
+        type: 'A',
+        artnr: cols[1],
+        kurztext1: cols[2],
+        kurztext2: cols[3],
+        einheit: cols[4],
+        ean: cols[5],
+        matchcode: cols[6],
+        warengruppe: cols[7],
+        rabattgruppe: cols[8],
+      };
+    case 'B':
+      return { type: 'B', artnr: cols[1], katalogseite: cols[2], steuer_merker: cols[3] };
+    case 'T':
+      return { type: 'T', artnr: cols[1], text: cols[2] };
+    case 'P':
+      return {
+        type: 'P',
+        artnr: cols[1],
+        kennzeichen: cols[2] as '1' | '2',
+        betrag: cols[3],
+        einheit: cols[4],
+        gueltig_ab: cols[5],
+        gueltig_bis: cols[6],
+        kundennr: cols[7],
+      };
+    case 'Z':
+      return { type: 'Z', artnr: cols[1], von_menge: cols[2], aufabschlag: cols[3] };
+    case 'G':
+      return { type: 'G', artnr: cols[1], art: cols[2], dateiname: cols[3], beschreibung: cols[4] };
+    case 'J':
+      return { type: 'J', parent: cols[1], child: cols[2], menge: cols[3] };
+    case 'E':
+      return { type: 'E' } as AnyRecord;
+    default:
+      return null;
+  }
+}

--- a/src/datanorm/records.ts
+++ b/src/datanorm/records.ts
@@ -1,0 +1,89 @@
+export interface HeaderRecord {
+  type: 'V';
+  creator?: string;
+  currency?: string;
+  date?: string;
+}
+
+export interface WarengruppeRecord {
+  type: 'S';
+  hauptgruppe: string;
+  gruppe: string;
+  bezeichnung: string;
+}
+
+export interface RabattgruppeRecord {
+  type: 'R';
+  nummer: string;
+  bezeichnung: string;
+}
+
+export interface ArticleRecord {
+  type: 'A';
+  artnr: string;
+  kurztext1: string;
+  kurztext2?: string;
+  einheit: string;
+  ean?: string;
+  matchcode?: string;
+  warengruppe?: string;
+  rabattgruppe?: string;
+}
+
+export interface ArticleAddRecord {
+  type: 'B';
+  artnr: string;
+  katalogseite?: string;
+  steuer_merker?: string;
+}
+
+export interface TextRecord {
+  type: 'T';
+  artnr: string;
+  text: string;
+}
+
+export interface PriceRecord {
+  type: 'P';
+  artnr: string;
+  kennzeichen: '1'|'2';
+  betrag: string; // decimal as string
+  einheit: string;
+  gueltig_ab?: string;
+  gueltig_bis?: string;
+  kundennr?: string;
+}
+
+export interface PriceTierRecord {
+  type: 'Z';
+  artnr: string;
+  von_menge: string;
+  aufabschlag: string; // decimal string
+}
+
+export interface MediaRecord {
+  type: 'G';
+  artnr: string;
+  art: string;
+  dateiname: string;
+  beschreibung?: string;
+}
+
+export interface SetRecord {
+  type: 'J';
+  parent: string;
+  child: string;
+  menge: string;
+}
+
+export type AnyRecord =
+  | HeaderRecord
+  | WarengruppeRecord
+  | RabattgruppeRecord
+  | ArticleRecord
+  | ArticleAddRecord
+  | TextRecord
+  | PriceRecord
+  | PriceTierRecord
+  | MediaRecord
+  | SetRecord;

--- a/src/datanorm/validator.ts
+++ b/src/datanorm/validator.ts
@@ -1,0 +1,35 @@
+import { ArticleRecord, PriceRecord } from './records';
+
+export interface ValidationError {
+  field: string;
+  message: string;
+}
+
+export function validateArticle(rec: ArticleRecord, version: 'v4' | 'v5'): ValidationError[] {
+  const errors: ValidationError[] = [];
+  const maxEAN = version === 'v4' ? 13 : 18;
+  if (!rec.artnr) errors.push({ field: 'artnr', message: 'required' });
+  if (rec.artnr && rec.artnr.length > 15)
+    errors.push({ field: 'artnr', message: `max 15` });
+  if (!rec.kurztext1) errors.push({ field: 'kurztext1', message: 'required' });
+  if (rec.kurztext1 && rec.kurztext1.length > 40)
+    errors.push({ field: 'kurztext1', message: 'max 40' });
+  if (rec.kurztext2 && rec.kurztext2.length > 40)
+    errors.push({ field: 'kurztext2', message: 'max 40' });
+  if (rec.einheit && rec.einheit.length > 4)
+    errors.push({ field: 'einheit', message: 'max 4' });
+  if (rec.ean && rec.ean.length > maxEAN)
+    errors.push({ field: 'ean', message: `max ${maxEAN}` });
+  if (rec.matchcode && rec.matchcode.length > 15)
+    errors.push({ field: 'matchcode', message: 'max 15' });
+  return errors;
+}
+
+export function validatePrice(rec: PriceRecord, version: 'v4' | 'v5'): ValidationError[] {
+  const errors: ValidationError[] = [];
+  if (!['1', '2'].includes(rec.kennzeichen))
+    errors.push({ field: 'kennzeichen', message: 'invalid' });
+  if (rec.einheit && rec.einheit.length > (version === 'v4' ? 4 : 6))
+    errors.push({ field: 'einheit', message: `max ${version === 'v4' ? 4 : 6}` });
+  return errors;
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,0 +1,117 @@
+import Database from 'better-sqlite3';
+import fs from 'fs';
+import path from 'path';
+import { ArticleRecord } from '../datanorm/records';
+
+let db: Database.Database | null = null;
+
+export function getDb(dbPath = path.join(process.cwd(), 'datanorm.sqlite')): Database.Database {
+  if (!db) {
+    db = new Database(dbPath);
+    const schema = fs.readFileSync(path.join(__dirname, 'schema.sql'), 'utf8');
+    db.exec(schema);
+  }
+  return db;
+}
+
+export function withTransaction<T>(fn: () => T): T {
+  const database = getDb();
+  const tx = database.transaction(fn);
+  return tx();
+}
+
+export function upsertWarengruppe(code: { hauptgruppe: string; gruppe: string; bezeichnung: string }): number {
+  const db = getDb();
+  const sel = db.prepare('SELECT id FROM warengruppen WHERE hauptgruppe=? AND gruppe=?');
+  const row = sel.get(code.hauptgruppe, code.gruppe);
+  if (row) {
+    db.prepare('UPDATE warengruppen SET bezeichnung=? WHERE id=?').run(code.bezeichnung, row.id);
+    return row.id as number;
+  }
+  const result = db
+    .prepare('INSERT INTO warengruppen (hauptgruppe,gruppe,bezeichnung) VALUES (?,?,?)')
+    .run(code.hauptgruppe, code.gruppe, code.bezeichnung);
+  return result.lastInsertRowid as number;
+}
+
+export function upsertRabattgruppe(code: { nummer: string; bezeichnung: string }): number {
+  const db = getDb();
+  const row = db.prepare('SELECT id FROM rabattgruppen WHERE nummer=?').get(code.nummer);
+  if (row) {
+    db.prepare('UPDATE rabattgruppen SET bezeichnung=? WHERE id=?').run(code.bezeichnung, row.id);
+    return row.id as number;
+  }
+  const res = db
+    .prepare('INSERT INTO rabattgruppen (nummer,bezeichnung) VALUES (?,?)')
+    .run(code.nummer, code.bezeichnung);
+  return res.lastInsertRowid as number;
+}
+
+export function upsertArticle(rec: ArticleRecord & { warengruppe_id?: number; rabattgruppe_id?: number }): number {
+  const db = getDb();
+  const sel = db.prepare('SELECT id FROM articles WHERE artnr=?');
+  const row = sel.get(rec.artnr);
+  if (row) {
+    db.prepare(
+      `UPDATE articles SET kurztext1=@kurztext1, kurztext2=@kurztext2, einheit=@einheit, ean=@ean, matchcode=@matchcode, warengruppe_id=@warengruppe_id, rabattgruppe_id=@rabattgruppe_id, katalogseite=@katalogseite, steuer_merker=@steuer_merker, updated_at=CURRENT_TIMESTAMP WHERE id=@id`
+    ).run({ ...rec, id: row.id });
+    return row.id as number;
+  }
+  const res = db
+    .prepare(
+      `INSERT INTO articles (artnr, kurztext1, kurztext2, einheit, ean, matchcode, warengruppe_id, rabattgruppe_id, katalogseite, steuer_merker) VALUES (@artnr,@kurztext1,@kurztext2,@einheit,@ean,@matchcode,@warengruppe_id,@rabattgruppe_id,@katalogseite,@steuer_merker)`
+    )
+    .run(rec);
+  return res.lastInsertRowid as number;
+}
+
+export function setArticleText(articleId: number, text: string) {
+  const db = getDb();
+  db.prepare('INSERT OR REPLACE INTO article_texts (article_id, langtext) VALUES (?,?)').run(articleId, text);
+}
+
+export function insertPrice(rec: {
+  article_id: number;
+  typ: string;
+  betrag_cent: number;
+  einheit: string;
+  gueltig_ab?: string;
+  gueltig_bis?: string;
+  kundennr?: string;
+}): number {
+  const db = getDb();
+  const res = db
+    .prepare(
+      `INSERT INTO prices (article_id, typ, betrag_cent, einheit, gueltig_ab, gueltig_bis, kundennr) VALUES (@article_id,@typ,@betrag_cent,@einheit,@gueltig_ab,@gueltig_bis,@kundennr)`
+    )
+    .run(rec);
+  return res.lastInsertRowid as number;
+}
+
+export function insertPriceTier(rec: { price_id: number; von_menge: string; zu_abaufschlag_cent: number }) {
+  const db = getDb();
+  db.prepare('INSERT INTO price_tiers (price_id,von_menge,zu_abaufschlag_cent) VALUES (?,?,?)').run(
+    rec.price_id,
+    rec.von_menge,
+    rec.zu_abaufschlag_cent
+  );
+}
+
+export function insertMedia(rec: { article_id: number; art: string; dateiname: string; beschreibung?: string }) {
+  const db = getDb();
+  db.prepare('INSERT INTO media (article_id, art, dateiname, beschreibung) VALUES (?,?,?,?)').run(
+    rec.article_id,
+    rec.art,
+    rec.dateiname,
+    rec.beschreibung
+  );
+}
+
+export function insertSet(rec: { parent_id: number; child_id: number; menge: string }) {
+  const db = getDb();
+  db.prepare('INSERT OR REPLACE INTO article_sets (parent_id, child_id, menge) VALUES (?,?,?)').run(
+    rec.parent_id,
+    rec.child_id,
+    rec.menge
+  );
+}

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -1,0 +1,86 @@
+CREATE TABLE IF NOT EXISTS suppliers (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT,
+  created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS warengruppen (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  hauptgruppe TEXT(3),
+  gruppe TEXT(10),
+  bezeichnung TEXT(40)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_warengruppe_code ON warengruppen(hauptgruppe, gruppe);
+
+CREATE TABLE IF NOT EXISTS rabattgruppen (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  nummer TEXT(4),
+  bezeichnung TEXT(40)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_rabatt_nummer ON rabattgruppen(nummer);
+
+CREATE TABLE IF NOT EXISTS articles (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  artnr TEXT(15) UNIQUE,
+  kurztext1 TEXT(40),
+  kurztext2 TEXT(40),
+  einheit TEXT(4),
+  ean TEXT,
+  matchcode TEXT(15),
+  hersteller_nr TEXT,
+  katalogseite TEXT,
+  steuer_merker TEXT,
+  warengruppe_id INTEGER,
+  rabattgruppe_id INTEGER,
+  aktiv INTEGER DEFAULT 1,
+  created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_articles_wg ON articles(warengruppe_id);
+CREATE INDEX IF NOT EXISTS idx_articles_rg ON articles(rabattgruppe_id);
+
+CREATE TABLE IF NOT EXISTS article_texts (
+  article_id INTEGER PRIMARY KEY,
+  langtext TEXT,
+  FOREIGN KEY(article_id) REFERENCES articles(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS article_sets (
+  parent_id INTEGER,
+  child_id INTEGER,
+  menge TEXT,
+  PRIMARY KEY(parent_id, child_id),
+  FOREIGN KEY(parent_id) REFERENCES articles(id) ON DELETE CASCADE,
+  FOREIGN KEY(child_id) REFERENCES articles(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS prices (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  article_id INTEGER,
+  typ TEXT,
+  betrag_cent INTEGER,
+  einheit TEXT,
+  gueltig_ab TEXT,
+  gueltig_bis TEXT,
+  kundennr TEXT,
+  FOREIGN KEY(article_id) REFERENCES articles(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_prices_article ON prices(article_id);
+
+CREATE TABLE IF NOT EXISTS price_tiers (
+  price_id INTEGER,
+  von_menge TEXT,
+  zu_abaufschlag_cent INTEGER,
+  PRIMARY KEY(price_id, von_menge),
+  FOREIGN KEY(price_id) REFERENCES prices(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS media (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  article_id INTEGER,
+  art TEXT(2),
+  dateiname TEXT,
+  beschreibung TEXT,
+  FOREIGN KEY(article_id) REFERENCES articles(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_media_article ON media(article_id);

--- a/tests/datanorm.import.spec.ts
+++ b/tests/datanorm.import.spec.ts
@@ -1,0 +1,106 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import iconv from 'iconv-lite';
+import Database from 'better-sqlite3';
+import { importDatanorm } from '../src/datanorm';
+
+function tmpDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function pad(val: string, len: number): string {
+  return (val || '').padEnd(len, ' ');
+}
+
+describe('DATANORM Import', () => {
+  test('imports v5 data with encoding', async () => {
+    const dir = tmpDir('dnv5-');
+    const lines = [
+      'V;ERST;EUR;20240101',
+      'S;001;001;WGr\u00e4te',
+      'R;0001;Rabatt',
+      'A;ART1;Kurztext1;Kurztext2;ST;123456789012345678;MATCH1;001;0001',
+      'B;ART1;10;T',
+      'T;ART1;Langtext1 \u00e4',
+      'T;ART1;Langtext2',
+      'P;ART1;1;12,34;ST;20240101;20241231',
+      'Z;ART1;10;1,00',
+      'G;ART1;I;bild.jpg;Bild',
+      'E',
+    ];
+    const buf = iconv.encode(lines.join('\n'), 'cp850');
+    fs.writeFileSync(path.join(dir, 'DATANORM.001'), buf);
+    process.chdir(dir);
+    const res = await importDatanorm({ input: dir });
+    expect(res.version).toBe('v5');
+    const db = new Database(path.join(dir, 'datanorm.sqlite'));
+    const art = db.prepare('SELECT * FROM articles').get();
+    expect(art.artnr).toBe('ART1');
+    const txt = db.prepare('SELECT langtext FROM article_texts').get();
+    expect(txt.langtext).toBe('Langtext1 ä\nLangtext2');
+    const media = db.prepare('SELECT COUNT(*) as c FROM media').get();
+    expect(media.c).toBe(1);
+  });
+
+  test('imports v4 data', async () => {
+    const dir = tmpDir('dnv4-');
+    const a =
+      'A' +
+      pad('ART2', 15) +
+      pad('Kurztext1', 40) +
+      pad('Kurztext2', 40) +
+      pad('ST', 4) +
+      pad('1234567890123', 13) +
+      pad('MATCH2', 15) +
+      pad('001', 10) +
+      pad('0001', 4);
+    const t = 'T' + pad('ART2', 15) + pad('Langtext', 40);
+    const p =
+      'P' +
+      pad('ART2', 15) +
+      pad('1', 1) +
+      pad('001234', 8) +
+      pad('ST', 4) +
+      pad('20240101', 8) +
+      pad('20241231', 8);
+    const lines = ['V', 'S001001WGr', 'R0001Rabatt', a, t, p, 'E'];
+    fs.writeFileSync(path.join(dir, 'DATANORM.001'), lines.join('\n'));
+    process.chdir(dir);
+    const res = await importDatanorm({ input: dir });
+    expect(res.version).toBe('v4');
+    const db = new Database(path.join(dir, 'datanorm.sqlite'));
+    const art = db.prepare('SELECT * FROM articles').get();
+    expect(art.artnr).toBe('ART2');
+  });
+
+  test('rollback on high error ratio', async () => {
+    const dir = tmpDir('dnerr-');
+    const good =
+      'A' +
+      pad('A1', 15) +
+      pad('T1', 40) +
+      pad('', 40) +
+      pad('ST', 4) +
+      pad('', 13) +
+      pad('', 15) +
+      pad('', 10) +
+      pad('', 4);
+    const bad =
+      'A' +
+      pad('TOO-LONG-ARTICLE-NUMBER', 15) +
+      pad('T2', 40) +
+      pad('', 40) +
+      pad('ST', 4) +
+      pad('', 13) +
+      pad('', 15) +
+      pad('', 10) +
+      pad('', 4);
+    fs.writeFileSync(path.join(dir, 'DATANORM.001'), [good, bad, 'E'].join('\n'));
+    process.chdir(dir);
+    const res = await importDatanorm({ input: dir });
+    const db = new Database(path.join(dir, 'datanorm.sqlite'));
+    const count = db.prepare('SELECT COUNT(*) as c FROM articles').get();
+    expect(count.c).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add streaming DATANORM v4/v5 importer with auto detection
- store articles, prices, texts, media and groups in SQLite
- provide CLI and tests

## Testing
- `npm run typecheck`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a770b416e48325be9beb9902ba716b