### PR TITLE
chore: update test tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "rebuild-native": "electron-rebuild -f -w better-sqlite3 -w sharp",
     "postinstall": "electron-builder install-app-deps",
     "test": "jest",
-    "typecheck": "tsc -p tsconfig.main.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
     "electron": "^30.0.0",
@@ -55,7 +55,7 @@
     "@vitejs/plugin-react": "^5.0.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
-    "@types/jest": "^29.5.4"
+    "@types/jest": "^29.5.12"
   },
   "build": {
     "appId": "com.cloudia.etiketten",


### PR DESCRIPTION
## Summary
- update test script and typecheck script
- bump @types/jest to latest

## Testing
- `npm run typecheck`
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: E403 Forbidden for @types/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68a7747ed3e48325b7e400599ef336e0