### PR TITLE
Align article info and barcode in label PDFs

### DIFF
--- a/src/renderer/components/LabelPreview.tsx
+++ b/src/renderer/components/LabelPreview.tsx
@@ -16,11 +16,21 @@ const LabelPreview: React.FC<Props> = ({ opts }) => {
     ctx.strokeStyle = '#000';
     ctx.strokeRect(0, 0, 300, 150);
     ctx.fillStyle = '#000';
-    if (opts.showShortText) ctx.fillText('Beispieltext', 10, 20);
-    if (opts.showArticleNumber) ctx.fillText('Art.-Nr: 12345', 10, 140);
-    if (opts.showListPrice) ctx.fillText('9,99 €', 200, 30);
+    let y = 20;
+    if (opts.showArticleNumber) {
+      ctx.fillText('Art.-Nr: 12345', 10, y);
+      y += 20;
+    }
+    if (opts.showShortText) {
+      ctx.fillText('Beispieltext', 10, y);
+      y += 20;
+    }
+    if (opts.showListPrice) {
+      ctx.fillText('9,99 €', 10, y);
+      y += 20;
+    }
     if (opts.showEan) {
-      ctx.fillRect(200, 40, 80, 40);
+      ctx.fillRect(10, 90, 120, 40);
     }
     if (opts.showImage) {
       ctx.fillStyle = '#ccc';

--- a/src/renderer/lib/labels.ts
+++ b/src/renderer/lib/labels.ts
@@ -50,9 +50,11 @@ export async function renderEanPng(
     width: Math.max(1, Math.floor(pxW / 180)),
     height: Math.max(30, Math.floor(pxH * 0.65)),
     displayValue: true,
-    font: 'helvetica',
-    fontSize: Math.floor(pxH * 0.18),
-    textMargin: Math.floor(pxH * 0.03),
+    text: code,
+    font: 'Helvetica',
+    fontSize: 16,
+    textMargin: 5,
+    textAlign: 'center',
     margin: 0,
   };
 

--- a/src/renderer/lib/labelsPdf.ts
+++ b/src/renderer/lib/labelsPdf.ts
@@ -31,6 +31,16 @@ export async function generateLabelsPdf(
       const x = conf.marginX + col * (conf.labelW + conf.gutterX);
       const y = conf.marginY + row * (conf.labelH + conf.gutterY);
 
+      let cursorY = y + 2;
+
+      if (item.articleNumber) {
+        doc.setFont('helvetica', 'normal');
+        doc.setFontSize(8);
+        doc.text(item.articleNumber, x + 3, cursorY, { baseline: 'top' });
+        const artHeight = doc.getTextDimensions(item.articleNumber).h;
+        cursorY += artHeight + 2;
+      }
+
       let fontStyle: 'normal' | 'italic' = 'normal';
       let fontSize = 11;
       if (item.name && item.name.toLowerCase().includes('nicht mehr verwenden')) {
@@ -45,12 +55,12 @@ export async function generateLabelsPdf(
         const second = lines[1];
         lines = [lines[0], second.substring(0, second.length - 3) + '...'];
       }
-      doc.text(lines as any, x + 3, y + 2, {
+      doc.text(lines as any, x + 3, cursorY, {
         maxWidth,
         baseline: 'top',
       });
       const nameHeight = doc.getTextDimensions(lines).h;
-      let cursorY = y + 2 + nameHeight + 2;
+      cursorY += nameHeight + 2;
 
       if (item.price != null) {
         doc.setFont('helvetica', 'bold');
@@ -86,11 +96,7 @@ export async function generateLabelsPdf(
         if (barcodeCount % 8 === 0) await Promise.resolve();
       }
 
-      if (item.articleNumber) {
-        doc.setFont('helvetica', 'normal');
-        doc.setFontSize(8);
-        doc.text(item.articleNumber, x + 3, y + conf.labelH - 1);
-      }
+
 
       col++;
       if (col >= conf.cols) {


### PR DESCRIPTION
## Summary
- Move article number above title and align all label text and barcode on left edge
- Restrict barcode text to EAN digits and centralize barcode styling
- Update preview and main PDF generator to match new layout

## Testing
- `npm test` *(fails: Cannot find name 'describe'...)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ac28691c3083258f5f8ffc02211eca