### PR TITLE
Ensure barcode placed below price in label PDFs

### DIFF
--- a/src/renderer/lib/labelsPdf.ts
+++ b/src/renderer/lib/labelsPdf.ts
@@ -84,14 +84,16 @@ export async function generateLabelsPdf(
           conf.labelW - 6,
           conf.barcodeH
         );
+        const barcodeY = cursorY; // start barcode below price with margin
         doc.addImage(
           png,
           'PNG',
           x + 3,
-          y + conf.labelH - conf.barcodeH - 1,
+          barcodeY,
           conf.labelW - 6,
           conf.barcodeH
         );
+        cursorY = barcodeY + conf.barcodeH;
         barcodeCount++;
         if (barcodeCount % 8 === 0) await Promise.resolve();
       }


### PR DESCRIPTION
## Summary
- Keep barcode rendering in PDF labels below the price with consistent margin
- Maintain left alignment and sequential flow to prevent price overlap

## Testing
- `npm test` *(fails: Cannot find name 'describe'; missing jest types)*

------
https://chatgpt.com/codex/tasks/task_e_68ac31aa20488325bb6875b68b54a70d