### PR TITLE
fix label layout to stack text and barcode

### DIFF
--- a/src/main/labels/pdf.ts
+++ b/src/main/labels/pdf.ts
@@ -59,17 +59,25 @@ export async function generateLabelsPdf(items: Array<{ articleId: string; qty: n
       cursorY = doc.y + mm(2);
     }
     if (it.options.showListPrice && art.listPrice) {
-      doc.fontSize(16).font('Helvetica-Bold').text(`${art.listPrice.toFixed(2)} €`, mm(2), cursorY);
+      doc
+        .fontSize(16)
+        .font('Helvetica-Bold')
+        .text(`${art.listPrice.toFixed(2)} €`, mm(2), cursorY);
       doc.font('Helvetica');
-      cursorY = doc.y + mm(2);
+      cursorY = doc.y + mm(3);
     }
     if (it.options.showImage && art.imagePath && fs.existsSync(art.imagePath)) {
-      doc.image(art.imagePath, mm(2), cursorY, { width: mm(38), height: mm(18), fit: [mm(38), mm(18)] });
-      cursorY += mm(18) + mm(2);
+      doc.image(art.imagePath, mm(2), cursorY, {
+        width: mm(38),
+        height: mm(18),
+        fit: [mm(38), mm(18)],
+      });
+      cursorY += mm(18) + mm(3);
     }
     if (it.options.showEan && art.ean) {
       const png = await renderBarcode(art.ean);
-      doc.image(png, mm(2), PAGE.h - mm(22) - mm(2), { width: mm(48), height: mm(22) });
+      doc.image(png, mm(2), cursorY, { width: mm(48), height: mm(22) });
+      cursorY += mm(22);
     }
   }
 

--- a/src/renderer/components/LabelPreview.tsx
+++ b/src/renderer/components/LabelPreview.tsx
@@ -29,13 +29,16 @@ const LabelPreview: React.FC<Props> = ({ opts }) => {
       ctx.fillText('9,99 €', 10, y);
       y += 20;
     }
-    if (opts.showEan) {
-      ctx.fillRect(10, 90, 120, 40);
-    }
     if (opts.showImage) {
       ctx.fillStyle = '#ccc';
-      ctx.fillRect(10, 60, 60, 60);
+      ctx.fillRect(10, y, 60, 60);
       ctx.fillStyle = '#000';
+      y += 60;
+    }
+    if (opts.showEan) {
+      y += 10;
+      ctx.fillRect(10, y, 120, 40);
+      y += 40;
     }
   }, [opts]);
   return <canvas ref={canvasRef} width={300} height={150} />;

--- a/src/renderer/lib/labelsPdf.ts
+++ b/src/renderer/lib/labelsPdf.ts
@@ -68,7 +68,7 @@ export async function generateLabelsPdf(
         const priceStr = currency.format(item.price);
         doc.text(priceStr, x + 3, cursorY, { baseline: 'top' });
         const priceHeight = doc.getTextDimensions(priceStr).h;
-        cursorY += priceHeight + 2;
+        cursorY += priceHeight + 3;
       }
 
       let code: string | undefined = undefined;
@@ -84,7 +84,7 @@ export async function generateLabelsPdf(
           conf.labelW - 6,
           conf.barcodeH
         );
-        const barcodeY = cursorY; // start barcode below price with margin
+        const barcodeY = cursorY;
         doc.addImage(
           png,
           'PNG',


### PR DESCRIPTION
## Summary
- prevent overlapping barcode by stacking label fields vertically
- preview now renders article text, price, image and barcode in separate blocks

## Testing
- `npm test` *(fails: Cannot find name 'describe')*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ac34707b9c83259c558a9df212ad8b