### PR TITLE
Improve label layout and barcode rendering

### DIFF
--- a/src/renderer/components/LabelPreview.tsx
+++ b/src/renderer/components/LabelPreview.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import type { LabelOptions } from './LabelOptionsPane';
 
 interface Props {
@@ -6,42 +6,21 @@ interface Props {
 }
 
 const LabelPreview: React.FC<Props> = ({ opts }) => {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-  useEffect(() => {
-    const ctx = canvasRef.current?.getContext('2d');
-    if (!ctx) return;
-    ctx.clearRect(0, 0, 300, 150);
-    ctx.fillStyle = '#fff';
-    ctx.fillRect(0, 0, 300, 150);
-    ctx.strokeStyle = '#000';
-    ctx.strokeRect(0, 0, 300, 150);
-    ctx.fillStyle = '#000';
-    let y = 20;
-    if (opts.showArticleNumber) {
-      ctx.fillText('Art.-Nr: 12345', 10, y);
-      y += 20;
-    }
-    if (opts.showShortText) {
-      ctx.fillText('Beispieltext', 10, y);
-      y += 20;
-    }
-    if (opts.showListPrice) {
-      ctx.fillText('9,99 €', 10, y);
-      y += 20;
-    }
-    if (opts.showImage) {
-      ctx.fillStyle = '#ccc';
-      ctx.fillRect(10, y, 60, 60);
-      ctx.fillStyle = '#000';
-      y += 60;
-    }
-    if (opts.showEan) {
-      y += 10;
-      ctx.fillRect(10, y, 120, 40);
-      y += 40;
-    }
-  }, [opts]);
-  return <canvas ref={canvasRef} width={300} height={150} />;
+  return (
+    <div className="label">
+      {opts.showArticleNumber && <div className="label__sku">Art.-Nr: 12345</div>}
+      {opts.showShortText && <div className="label__title">Beispieltext</div>}
+      {opts.showListPrice && <div className="label__price">9,99 €</div>}
+      {opts.showImage && <div className="label__image" />}
+      {opts.showEan && (
+        <div className="label__barcode">
+          <svg width="120" height="40">
+            <rect width="120" height="40" fill="#000" />
+          </svg>
+        </div>
+      )}
+    </div>
+  );
 };
 
 export default LabelPreview;

--- a/src/renderer/lib/labels.ts
+++ b/src/renderer/lib/labels.ts
@@ -50,12 +50,13 @@ export async function renderEanPng(
     width: Math.max(1, Math.floor(pxW / 180)),
     height: Math.max(30, Math.floor(pxH * 0.65)),
     displayValue: true,
-    text: code,
     font: 'Helvetica',
-    fontSize: 16,
-    textMargin: 5,
+    fontSize: 14,
+    textMargin: 4,
     textAlign: 'center',
     margin: 0,
+    marginTop: 0,
+    marginBottom: 0,
   };
 
   try {

--- a/src/renderer/lib/labelsPdf.ts
+++ b/src/renderer/lib/labelsPdf.ts
@@ -75,7 +75,8 @@ export async function generateLabelsPdf(
       if (item.ean && isValidEan13(item.ean)) {
         code = item.ean;
       } else if (item.articleNumber) {
-        code = fromArticleToEan13(item.articleNumber) || item.articleNumber;
+        const ean = fromArticleToEan13(item.articleNumber);
+        if (ean) code = ean;
       }
 
       if (code) {

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -2,3 +2,41 @@ body {
   margin: 0;
   font-family: sans-serif;
 }
+
+.label {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.label__sku,
+.label__title,
+.label__price,
+.label__barcode,
+.label__image {
+  display: block;
+  width: 100%;
+}
+
+.label__price {
+  font-size: 18px;
+  font-weight: bold;
+  margin: 4px 0 8px 0;
+  line-height: 1.3;
+}
+
+.label__barcode {
+  margin-top: 10px;
+}
+
+.label__barcode svg,
+.label__barcode canvas {
+  display: block;
+  margin: 0;
+}
+
+.label__image {
+  width: 60px;
+  height: 60px;
+  background: #ccc;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "sourceMap": true,
-    "types": ["node"]
+    "types": ["node", "jest"]
   },
     "include": ["src/main/**/*.ts", "src/preload.ts", "src/renderer/**/*.d.ts", "src/types/**/*.d.ts"]
   }


### PR DESCRIPTION
## Summary
- Render label preview with dedicated block elements for article number, title, price and barcode
- Apply vertical flex layout with spacing to prevent overlap between price and barcode
- Configure JsBarcode with consistent margins and font settings while dropping article-number fallbacks

## Testing
- `npm run typecheck`
- `npm test` *(fails: src/datanorm/importer.ts:153:14 - error TS2678)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3613a588832587db22cd6b995c43