### PR TITLE
fix: stack label fields and separate barcode

### DIFF
--- a/src/renderer/components/LabelPreview.tsx
+++ b/src/renderer/components/LabelPreview.tsx
@@ -8,10 +8,10 @@ interface Props {
 const LabelPreview: React.FC<Props> = ({ opts }) => {
   return (
     <div className="label">
-      {opts.showArticleNumber && <div className="label__sku">Art.-Nr: 12345</div>}
+      {opts.showArticleNumber && <div className="label__sku">12345</div>}
       {opts.showShortText && <div className="label__title">Beispieltext</div>}
-      {opts.showListPrice && <div className="label__price">9,99 €</div>}
       {opts.showImage && <div className="label__image" />}
+      {opts.showListPrice && <div className="label__price">9,99 €</div>}
       {opts.showEan && (
         <div className="label__barcode">
           <svg width="120" height="40">

--- a/src/renderer/lib/labelsPdf.ts
+++ b/src/renderer/lib/labelsPdf.ts
@@ -68,7 +68,7 @@ export async function generateLabelsPdf(
         const priceStr = currency.format(item.price);
         doc.text(priceStr, x + 3, cursorY, { baseline: 'top' });
         const priceHeight = doc.getTextDimensions(priceStr).h;
-        cursorY += priceHeight + 3;
+        cursorY += priceHeight + 4;
       }
 
       let code: string | undefined = undefined;

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -7,6 +7,9 @@ body {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  gap: 4px;
+  padding-left: 3mm;
+  page-break-inside: avoid;
 }
 
 .label__sku,
@@ -21,18 +24,20 @@ body {
 .label__price {
   font-size: 18px;
   font-weight: bold;
-  margin: 4px 0 8px 0;
-  line-height: 1.3;
+  margin: 4px 0 0 0;
+  line-height: 1.4;
 }
 
 .label__barcode {
-  margin-top: 10px;
+  margin-top: 12px;
+  position: static;
 }
 
 .label__barcode svg,
 .label__barcode canvas {
   display: block;
   margin: 0;
+  position: static;
 }
 
 .label__image {


### PR DESCRIPTION
## Summary
- ensure label fields flow top-to-bottom with padding and print-safe spacing
- place price above barcode in preview and add barcode margin
- leave more room before barcode in PDF generator to avoid overlaps

## Testing
- `npm test` *(fails: Type '"E"' is not comparable to type '"J" | "V" | "S" | "R" | "A" | "B" | "T" | "P" | "Z" | "G"')*

------
https://chatgpt.com/codex/tasks/task_e_68ac394fad60832596db735a3366df39