### PR TITLE
Improve label spacing and barcode encoding

### DIFF
--- a/src/renderer/lib/labels.ts
+++ b/src/renderer/lib/labels.ts
@@ -31,8 +31,8 @@ export const fromArticleToEan13 = (artnr: string): string | null => {
   return `${d12}${check}`;
 };
 
-export async function renderEanPng(
-  code: string,
+export async function renderBarcodePng(
+  artnr: string,
   widthMm: number,
   heightMm: number,
   dpi = 300
@@ -43,28 +43,36 @@ export async function renderEanPng(
   canvas.width = pxW;
   canvas.height = pxH;
 
+  const digits = onlyDigits(artnr);
+  let format: 'EAN13' | 'CODE128' = 'CODE128';
+  let code = artnr;
+  let text = artnr;
+
+  if (/^\d{13}$/.test(digits)) {
+    const d12 = digits.slice(0, 12);
+    const check = eanChecksum12(d12);
+    code = `${d12}${check}`;
+    text = code;
+    format = 'EAN13';
+  }
+
   const opts: any = {
-    format: 'EAN13',
+    format,
     lineColor: '#000',
     background: '#fff',
     width: Math.max(1, Math.floor(pxW / 180)),
     height: Math.max(30, Math.floor(pxH * 0.65)),
     displayValue: true,
+    text,
     font: 'Helvetica',
     fontSize: 14,
     textMargin: 4,
     textAlign: 'center',
-    margin: 0,
     marginTop: 0,
     marginBottom: 0,
   };
 
-  try {
-    JsBarcode(canvas, code, opts);
-  } catch {
-    opts.format = 'CODE128';
-    JsBarcode(canvas, code, opts);
-  }
+  JsBarcode(canvas, code, opts);
   return canvas.toDataURL('image/png');
 }
 

--- a/src/renderer/lib/labelsPdf.ts
+++ b/src/renderer/lib/labelsPdf.ts
@@ -1,5 +1,5 @@
 import { jsPDF } from 'jspdf';
-import { A4_3x8, LabelConfig, fromArticleToEan13, isValidEan13, renderEanPng } from './labels';
+import { A4_3x8, LabelConfig, renderBarcodePng } from './labels';
 
 export type CartItem = {
   name: string;
@@ -71,17 +71,9 @@ export async function generateLabelsPdf(
         cursorY += priceHeight + 4;
       }
 
-      let code: string | undefined = undefined;
-      if (item.ean && isValidEan13(item.ean)) {
-        code = item.ean;
-      } else if (item.articleNumber) {
-        const ean = fromArticleToEan13(item.articleNumber);
-        if (ean) code = ean;
-      }
-
-      if (code) {
-        const png = await renderEanPng(
-          code,
+      if (item.articleNumber) {
+        const png = await renderBarcodePng(
+          item.articleNumber,
           conf.labelW - 6,
           conf.barcodeH
         );

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -9,7 +9,6 @@ body {
   align-items: flex-start;
   gap: 4px;
   padding-left: 3mm;
-  page-break-inside: avoid;
 }
 
 .label__sku,
@@ -31,6 +30,7 @@ body {
 .label__barcode {
   margin-top: 12px;
   position: static;
+  overflow: visible;
 }
 
 .label__barcode svg,
@@ -44,4 +44,11 @@ body {
   width: 60px;
   height: 60px;
   background: #ccc;
+}
+
+@media print {
+  .label {
+    margin-bottom: 2cm;
+    page-break-inside: avoid;
+  }
 }


### PR DESCRIPTION
## Summary
- ensure each printed label has 2cm bottom margin and avoids page breaks
- render barcodes from article numbers (EAN13 when numeric, otherwise CODE128)
- update PDF label generation to display article numbers and prevent barcode clipping

## Testing
- `npm test` *(fails: src/datanorm/importer.ts:153:14 - Type '"E"' is not comparable to type '"J" | "V" | "S" | "R" | "A" | "B" | "T" | "P" | "Z" | "G"')*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ac3fd30838832580dcd930b3c3ebfb