### PR TITLE
feat: implement category management

### DIFF
--- a/__mocks__/electron.ts
+++ b/__mocks__/electron.ts
@@ -1,0 +1,5 @@
+export const app = {
+  getPath: () => process.env.TEST_DB_DIR || '/tmp',
+};
+export const ipcMain = {} as any;
+export const dialog = {} as any;

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -11,6 +11,8 @@ import {
   searchAllArticles,
   listCategories,
   createCategory,
+  renameCategory,
+  deleteCategory,
 } from '../db';
 import { registerCartHandlers } from './cart';
 import { registerLabelsHandlers } from './labels';
@@ -27,15 +29,19 @@ export function registerIpcHandlers() {
     return res;
   });
 
-    ipcMain.handle('articles:search', async (_e, opts) => searchArticles(opts));
-    ipcMain.handle('articles:searchAll', async (_e, opts) => searchAllArticles(opts));
+  ipcMain.handle('articles:search', async (_e, opts) => searchArticles(opts));
+  ipcMain.handle('articles:searchAll', async (_e, opts) => searchAllArticles(opts));
 
-    ipcMain.handle('custom:create', (_e, payload) => createCustomArticle(payload));
-    ipcMain.handle('custom:update', (_e, { id, patch }) => updateCustomArticle(id, patch));
-    ipcMain.handle('custom:delete', (_e, id) => deleteCustomArticle(id));
+  ipcMain.handle('custom:create', (_e, payload) => createCustomArticle(payload));
+  ipcMain.handle('custom:update', (_e, { id, patch }) => updateCustomArticle(id, patch));
+  ipcMain.handle('custom:delete', (_e, id) => deleteCustomArticle(id));
 
   ipcMain.handle('categories:list', () => listCategories());
   ipcMain.handle('categories:create', (_e, name) => createCategory(name));
+  ipcMain.handle('categories:update', (_e, { id, name }) => renameCategory(id, name));
+  ipcMain.handle('categories:delete', (_e, payload) =>
+    deleteCategory(payload.id, payload.mode, payload.reassignToId),
+  );
 
   ipcMain.handle('db:info', () => getDbInfo());
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -29,6 +29,9 @@ const bridge = {
   categories: {
     list: () => ipcRenderer.invoke('categories:list'),
     create: (name: string) => ipcRenderer.invoke('categories:create', name),
+    update: (id: number, name: string) => ipcRenderer.invoke('categories:update', { id, name }),
+    delete: (id: number, mode: 'reassign' | 'deleteArticles', reassignToId?: number | null) =>
+      ipcRenderer.invoke('categories:delete', { id, mode, reassignToId }),
   },
   dbInfo: () => ipcRenderer.invoke('db:info'),
   dbClear: () => ipcRenderer.invoke('db:clear'),

--- a/src/renderer/components/CategoryManager.tsx
+++ b/src/renderer/components/CategoryManager.tsx
@@ -1,0 +1,106 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Button,
+  Dialog,
+  DialogSurface,
+  DialogBody,
+  DialogTitle,
+  DialogActions,
+  Input,
+} from '@fluentui/react-components';
+
+const CategoryManager: React.FC<{ open: boolean; onClose: () => void }> = ({ open, onClose }) => {
+  const [categories, setCategories] = useState<{ id: number; name: string }[]>([]);
+  const [newName, setNewName] = useState('');
+
+  const load = async () => {
+    const list = await window.bridge?.categories?.list();
+    setCategories(list || []);
+  };
+
+  useEffect(() => {
+    if (open) load();
+  }, [open]);
+
+  const create = async () => {
+    if (!newName.trim()) return;
+    const res = await window.bridge?.categories?.create(newName.trim());
+    if (res && !res.error) {
+      setNewName('');
+      await load();
+      window.dispatchEvent(new Event('categories:refresh'));
+    }
+  };
+
+  const rename = async (id: number) => {
+    const current = categories.find((c) => c.id === id);
+    const name = prompt('Kategorie umbenennen', current?.name || '');
+    if (!name) return;
+    const res = await window.bridge?.categories?.update(id, name);
+    if (!res?.error) {
+      await load();
+      window.dispatchEvent(new Event('categories:refresh'));
+    } else {
+      alert('Fehler: ' + res.error);
+    }
+  };
+
+  const del = async (id: number) => {
+    const choice = prompt(
+      'Reassign zu Kategorie-ID oder leer für (keine). Tippe "delete" zum Löschen der Artikel.',
+      '',
+    );
+    if (choice === null) return;
+    let mode: 'reassign' | 'deleteArticles' = 'reassign';
+    let to: number | null | undefined = undefined;
+    if (choice.toLowerCase() === 'delete') {
+      mode = 'deleteArticles';
+    } else if (choice === '') {
+      to = null;
+    } else {
+      const num = Number(choice);
+      if (!isNaN(num)) to = num;
+    }
+    const res = await window.bridge?.categories?.delete(id, mode, to);
+    if (!res?.error) {
+      await load();
+      window.dispatchEvent(new Event('categories:refresh'));
+    } else {
+      alert('Fehler: ' + res.error);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(_, d) => !d.open && onClose()}>
+      <DialogSurface>
+        <DialogBody>
+          <DialogTitle>Kategorien verwalten</DialogTitle>
+          <div style={{ maxHeight: 300, overflowY: 'auto' }}>
+            {categories.map((c) => (
+              <div key={c.id} style={{ display: 'flex', gap: 8, marginBottom: 4 }}>
+                <div style={{ flex: 1 }}>{c.name}</div>
+                <Button size="small" onClick={() => rename(c.id)}>
+                  Umbenennen
+                </Button>
+                <Button size="small" appearance="secondary" onClick={() => del(c.id)}>
+                  Löschen
+                </Button>
+              </div>
+            ))}
+          </div>
+          <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+            <Input value={newName} onChange={(_, d) => setNewName(d.value)} placeholder="Neue Kategorie" />
+            <Button onClick={create}>Anlegen</Button>
+          </div>
+          <DialogActions>
+            <Button appearance="secondary" onClick={onClose}>
+              Schließen
+            </Button>
+          </DialogActions>
+        </DialogBody>
+      </DialogSurface>
+    </Dialog>
+  );
+};
+
+export default CategoryManager;

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -31,6 +31,12 @@ declare global {
         categories?: {
           list: () => Promise<{ id: number; name: string }[]>;
           create: (name: string) => Promise<{ id: number }>;
+          update: (id: number, name: string) => Promise<{ changes?: number; error?: string }>;
+          delete: (
+            id: number,
+            mode: 'reassign' | 'deleteArticles',
+            reassignToId?: number | null,
+          ) => Promise<{ deleted?: boolean; error?: string }>;
         };
       dbInfo?: () => Promise<{ path: string; rowCount: number }>;
       dbClear?: () => Promise<number>;

--- a/tests/categories.spec.ts
+++ b/tests/categories.spec.ts
@@ -1,0 +1,64 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+describe('Category CRUD', () => {
+  function setup() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'etik-cat-'));
+    process.env.TEST_DB_DIR = dir;
+    jest.resetModules();
+    return require('../src/main/db');
+  }
+
+  test('create and list', () => {
+    const db = setup();
+    const res = db.createCategory('Sanitär');
+    expect(res.id).toBeGreaterThan(0);
+    const list = db.listCategories();
+    expect(list.find((c: any) => c.name === 'Sanitär')).toBeTruthy();
+    const dup = db.createCategory('sanitär');
+    expect(dup.error).toBe('DUPLICATE_NAME');
+    const invalid = db.createCategory('');
+    expect(invalid.error).toBe('VALIDATION_ERROR');
+  });
+
+  test('rename', () => {
+    const db = setup();
+    const c1 = db.createCategory('Sanitär');
+    const ren = db.renameCategory(c1.id, 'Sanitär & Bad');
+    expect(ren.changes).toBe(1);
+    const list = db.listCategories();
+    expect(list[0].name).toBe('Sanitär & Bad');
+    const c2 = db.createCategory('Heizung');
+    const dup = db.renameCategory(c2.id, 'Sanitär & Bad');
+    expect(dup.error).toBe('DUPLICATE_NAME');
+  });
+
+  test('delete reassign to null', () => {
+    const db = setup();
+    const cat = db.createCategory('Heizung');
+    db.upsertArticles([{ articleNumber: 'A1', name: 'Test', category_id: cat.id }]);
+    const res = db.deleteCategory(cat.id, 'reassign', null);
+    expect(res.deleted).toBe(true);
+    const row = db.default.prepare('SELECT category_id FROM articles WHERE articleNumber=?').get('A1');
+    expect(row.category_id).toBeNull();
+  });
+
+  test('delete with explicit reassign missing reports error', () => {
+    const db = setup();
+    const cat = db.createCategory('X');
+    db.upsertArticles([{ articleNumber: 'A1', name: 'Test', category_id: cat.id }]);
+    const res = db.deleteCategory(cat.id, 'reassign');
+    expect(res.error).toBe('HAS_ARTICLES');
+  });
+
+  test('delete articles', () => {
+    const db = setup();
+    const cat = db.createCategory('Temp');
+    db.upsertArticles([{ articleNumber: 'A1', name: 'Test', category_id: cat.id }]);
+    const res = db.deleteCategory(cat.id, 'deleteArticles');
+    expect(res.deleted).toBe(true);
+    const cnt = db.default.prepare('SELECT COUNT(*) as c FROM articles').get();
+    expect(cnt.c).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add categories table updates and API
- introduce CategoryManager UI and wiring across panes
- add tests for category CRUD and electron mocks

## Testing
- `npm test` *(fails: DATANORM Import tests report missing tables)*
- `npx jest tests/categories.spec.ts`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ac5f38e370832590c8bd1d70d1436b