### PR TITLE
fix renderer build error

### DIFF
--- a/src/renderer/components/ArticleSearch.tsx
+++ b/src/renderer/components/ArticleSearch.tsx
@@ -301,7 +301,8 @@ const ArticleSearch: React.FC = () => {
     const totalSelected = selectedIds.size;
 
   return (
-    <div>
+    <>
+      <div>
         <div style={{ display: 'flex', gap: '4px', alignItems: 'center' }}>
           {dbInfoText && <div>{dbInfoText}</div>}
           <Input
@@ -621,8 +622,13 @@ const ArticleSearch: React.FC = () => {
           </div>
         </div>
       </div>
-      <CategoryManager open={catManagerOpen} onClose={() => setCatManagerOpen(false)} />
-    </div>
+      {catManagerOpen && (
+        <CategoryManager
+          open={catManagerOpen}
+          onClose={() => setCatManagerOpen(false)}
+        />
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- wrap ArticleSearch return with a fragment
- render CategoryManager conditionally to avoid adjacent JSX elements

## Testing
- `npm test` *(fails: The module '/workspace/etiketten/node_modules/better-sqlite3/build/Release/better_sqlite3.node' was compiled against a different Node.js version)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ac65896d748325af18608120c80de7