### PR TITLE
feat: add FTS article search

### DIFF
--- a/src/main/search.ts
+++ b/src/main/search.ts
@@ -1,0 +1,95 @@
+export interface ParsedQuery {
+  match?: string;
+  terms: string[];
+}
+
+// parse search string to FTS5 match expression
+export function parseSearch(input: string): ParsedQuery {
+  const groups: string[][] = [[]];
+  const terms: string[] = [];
+  let i = 0;
+  const len = input.length;
+
+  function isTokenChar(ch: string) {
+    return /[\p{L}\p{N}_\-./]/u.test(ch);
+  }
+
+  while (i < len) {
+    const ch = input[i];
+    if (ch === '"') {
+      // phrase search with escaping
+      i++;
+      let phrase = '';
+      let escaped = false;
+      while (i < len) {
+        const c = input[i];
+        if (escaped) {
+          phrase += c;
+          escaped = false;
+        } else if (c === '\\') {
+          escaped = true;
+        } else if (c === '"') {
+          break;
+        } else {
+          phrase += c;
+        }
+        i++;
+      }
+      if (i < len && input[i] === '"') i++; // skip closing quote
+      if (phrase.length >= 2) {
+        groups[groups.length - 1].push(`"${phrase.replace(/"/g, '""')}"`);
+        terms.push(phrase);
+      }
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      i++;
+      continue;
+    }
+    if (!isTokenChar(ch) && ch !== '-' && ch !== '*') {
+      i++;
+      continue;
+    }
+    let not = false;
+    if (ch === '-') {
+      not = true;
+      i++;
+    }
+    let word = '';
+    while (i < len) {
+      const c = input[i];
+      if (isTokenChar(c) || c === '*') {
+        word += c;
+        i++;
+      } else {
+        break;
+      }
+    }
+    const upper = word.toUpperCase();
+    if (!not && upper === 'OR') {
+      groups.push([]);
+      continue;
+    }
+    let prefix = false;
+    if (word.endsWith('*')) {
+      prefix = true;
+      word = word.slice(0, -1);
+    }
+    if (word.length >= 2) {
+      const token = word.replace(/"/g, '');
+      const part = prefix ? `${token}*` : token;
+      if (not) groups[groups.length - 1].push(`NOT ${part}`);
+      else {
+        groups[groups.length - 1].push(part);
+        terms.push(word);
+      }
+    }
+  }
+
+  const match = groups
+    .filter((g) => g.length)
+    .map((g) => g.join(' '))
+    .join(' OR ');
+
+  return { match: match || undefined, terms };
+}

--- a/src/renderer/components/ArticleSearch.tsx
+++ b/src/renderer/components/ArticleSearch.tsx
@@ -141,6 +141,19 @@ const ArticleSearch: React.FC = () => {
     }
   };
 
+  useEffect(() => {
+    if (!apiReady) return;
+    if (query.trim().length >= 2 || searchCategory !== undefined) {
+      setPage(1);
+      refreshList(1);
+    } else {
+      setItems([]);
+      setTotal(0);
+      setLoaded(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchCategory]);
+
   const prev = async () => {
     const p = page - 1;
     setPage(p);
@@ -309,7 +322,7 @@ const ArticleSearch: React.FC = () => {
             value={query}
             onChange={(_, d) => setQuery(d.value)}
             onKeyDown={onKeyDown}
-            placeholder="Suche"
+            placeholder="Suche wie bei Google: Wörter = UND, „…“ = Phrase, OR, -wort, * als Präfix"
             disabled={!apiReady || loading}
           />
           <select


### PR DESCRIPTION
## Summary
- build unicode FTS5 table for articles and keep it in sync via triggers
- parse Google-like queries into MATCH expressions and rank with bm25
- refresh article list on category change and hint advanced operators in UI

## Testing
- `npm run typecheck`
- `npm test` *(fails: The module '/workspace/etiketten/node_modules/better-sqlite3/build/Release/better_sqlite3.node' was compiled against a different Node.js version)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6e51cbdc83259d85c4e1210a77af