### PR TITLE
feat: add article media backend and label footer

### DIFF
--- a/src/main/db.migrations.ts
+++ b/src/main/db.migrations.ts
@@ -149,6 +149,20 @@ export function ensureSchema(db: Database) {
   }
   db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_categories_name ON categories(LOWER(name));`);
 
+  db.exec(`
+  CREATE TABLE IF NOT EXISTS article_media (
+    id INTEGER PRIMARY KEY,
+    article_id INTEGER NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
+    path TEXT NOT NULL,
+    alt TEXT,
+    is_primary INTEGER NOT NULL DEFAULT 1,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  );
+  `);
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_article_media_article_primary ON article_media(article_id, is_primary);`,
+  );
+
   // FTS table for fast article search
   try {
     db.exec(`CREATE VIRTUAL TABLE IF NOT EXISTS articles_fts USING fts5(

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -17,11 +17,13 @@ import {
 import { registerCartHandlers } from './cart';
 import { registerLabelsHandlers } from './labels';
 import { registerShellHandlers } from './shell';
+import { registerMediaHandlers } from './media';
 
 export function registerIpcHandlers() {
   registerCartHandlers();
   registerLabelsHandlers();
   registerShellHandlers();
+  registerMediaHandlers();
 
   ipcMain.handle('datanorm:import', async (_e, { filePath, mapping, categoryId }) => {
     const res = await importDatanormFile({ filePath, mapping, categoryId });

--- a/src/main/ipc/media.ts
+++ b/src/main/ipc/media.ts
@@ -1,0 +1,21 @@
+import { ipcMain } from 'electron';
+import { z } from 'zod';
+import { addPrimaryMedia, listMedia, removeMedia } from '../db';
+import { IPC_CHANNELS } from '../../shared/ipc';
+
+export function registerMediaHandlers() {
+  ipcMain.handle(IPC_CHANNELS.media.addPrimary, async (_e, payload) => {
+    const data = z
+      .object({ articleId: z.number(), filePath: z.string(), alt: z.string().optional() })
+      .parse(payload);
+    return addPrimaryMedia(data);
+  });
+  ipcMain.handle(IPC_CHANNELS.media.list, (_e, payload) => {
+    const data = z.object({ articleId: z.number() }).parse(payload);
+    return listMedia(data.articleId);
+  });
+  ipcMain.handle(IPC_CHANNELS.media.remove, (_e, payload) => {
+    const data = z.object({ mediaId: z.number() }).parse(payload);
+    return removeMedia(data.mediaId);
+  });
+}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -33,6 +33,12 @@ const bridge = {
     delete: (id: number, mode: 'reassign' | 'deleteArticles', reassignToId?: number | null) =>
       ipcRenderer.invoke('categories:delete', { id, mode, reassignToId }),
   },
+  media: {
+    addPrimary: (articleId: number, filePath: string, alt?: string) =>
+      ipcRenderer.invoke('media:addPrimary', { articleId, filePath, alt }),
+    list: (articleId: number) => ipcRenderer.invoke('media:list', { articleId }),
+    remove: (mediaId: number) => ipcRenderer.invoke('media:remove', { mediaId }),
+  },
   dbInfo: () => ipcRenderer.invoke('db:info'),
   dbClear: () => ipcRenderer.invoke('db:clear'),
 };

--- a/src/renderer/components/LabelPreview.tsx
+++ b/src/renderer/components/LabelPreview.tsx
@@ -19,6 +19,7 @@ const LabelPreview: React.FC<Props> = ({ opts }) => {
           </svg>
         </div>
       )}
+      <div className="label__footer">Elektro Brunner Johann</div>
     </div>
   );
 };

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -24,7 +24,22 @@ declare global {
           sortBy?: 'name' | 'articleNumber' | 'price';
           sortDir?: 'ASC' | 'DESC';
           categoryId?: number;
-        }) => Promise<{ items: { id?: number; articleNumber?: string; ean?: string; name: string; price?: number; unit?: string; productGroup?: string; category_id?: number; source: 'import' | 'custom' }[]; total: number; message?: string }>;
+        }) => Promise<{
+          items: {
+            id?: number;
+            articleNumber?: string;
+            ean?: string;
+            name: string;
+            price?: number;
+            unit?: string;
+            productGroup?: string;
+            category_id?: number;
+            source: 'import' | 'custom';
+            imagePath?: string | null;
+          }[];
+          total: number;
+          message?: string;
+        }>;
         customCreate?: (a: any) => Promise<{ id: number }>;
         customUpdate?: (id: number, patch: any) => Promise<{ changes: number }>;
         customDelete?: (id: number) => Promise<{ changes: number }>;
@@ -37,6 +52,11 @@ declare global {
             mode: 'reassign' | 'deleteArticles',
             reassignToId?: number | null,
           ) => Promise<{ deleted?: boolean; error?: string }>;
+        };
+        media?: {
+          addPrimary: (articleId: number, filePath: string, alt?: string) => Promise<any>;
+          list: (articleId: number) => Promise<any[]>;
+          remove: (mediaId: number) => Promise<any>;
         };
       dbInfo?: () => Promise<{ path: string; rowCount: number }>;
       dbClear?: () => Promise<number>;

--- a/src/renderer/lib/labelsPdf.ts
+++ b/src/renderer/lib/labelsPdf.ts
@@ -7,6 +7,7 @@ export type CartItem = {
   ean?: string;
   articleNumber?: string;
   qty: number;
+  imageData?: string;
 };
 
 export async function generateLabelsPdf(
@@ -71,6 +72,13 @@ export async function generateLabelsPdf(
         cursorY += priceHeight + 4;
       }
 
+      if (item.imageData) {
+        const maxW = conf.labelW - 6;
+        const imgH = conf.barcodeH; // rough height
+        doc.addImage(item.imageData, 'PNG', x + 3, cursorY, maxW, imgH);
+        cursorY += imgH + 4;
+      }
+
       if (item.articleNumber) {
         const png = await renderBarcodePng(
           item.articleNumber,
@@ -87,6 +95,10 @@ export async function generateLabelsPdf(
           conf.barcodeH
         );
         cursorY = barcodeY + conf.barcodeH;
+        doc.setFont('helvetica', 'normal');
+        doc.setFontSize(8);
+        doc.text('Elektro Brunner Johann', x + 3, cursorY + 4, { baseline: 'top' });
+        cursorY += 10;
         barcodeCount++;
         if (barcodeCount % 8 === 0) await Promise.resolve();
       }

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -46,6 +46,11 @@ body {
   background: #ccc;
 }
 
+.label__footer {
+  margin-top: 4px;
+  font-size: 8px;
+}
+
 @media print {
   .label {
     margin-bottom: 2cm;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -18,6 +18,11 @@ export const IPC_CHANNELS = {
   labels: {
     generate: 'ipc.labels.generate',
   },
+  media: {
+    addPrimary: 'ipc.media.addPrimary',
+    list: 'ipc.media.list',
+    remove: 'ipc.media.remove',
+  },
   dialog: {
     open: 'ipc.dialog.open',
   },
@@ -37,5 +42,13 @@ export const CartUpdateSchema = z.object({ id: z.string(), patch: z.object({ qty
 export const CartRemoveSchema = z.string();
 
 export const LabelsGenerateResultSchema = z.object({ pdfPath: z.string() });
+
+export const MediaAddPrimarySchema = z.object({
+  articleId: z.number().int(),
+  filePath: z.string(),
+  alt: z.string().optional(),
+});
+export const MediaListSchema = z.object({ articleId: z.number().int() });
+export const MediaRemoveSchema = z.object({ mediaId: z.number().int() });
 
 export const DialogOpenResultSchema = z.object({ filePaths: z.array(z.string()) });


### PR DESCRIPTION
## Summary
- add `article_media` table and helpers to store primary images
- expose media management via new IPC routes
- print fixed footer and optional article image on labels

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden for @fluentui/react)*

------
https://chatgpt.com/codex/tasks/task_e_68ad53f266c48325a2ad4090db74bd5e