### PR TITLE
Configure Jest and native rebuild for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@ Dabei startet Vite (Port 5173) und danach Electron. In der Konsole erscheinen ge
 Die Ansicht im Browser unter `http://localhost:5173` besitzt absichtlich keine Bridge und zeigt eine Warnleiste.
 Der Preload-Code in `src/preload.ts` wird dabei automatisch nach `src/main/preload.js` gebaut und von Electron geladen.
 
+### Tests
+
+Vor dem Ausführen der Jest-Tests müssen die nativen `better-sqlite3`-Bindings für Node gebaut werden:
+
+```bash
+npm run rebuild:node
+npm test
+```
+
+Nach den Tests kann mit `npm run rebuild:electron` wieder für die Electron-Laufzeit gebaut werden.
+
 ## Produktion
 
 ```bash

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,10 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  testMatch: ['**/tests/**/*.spec.ts']
+  testMatch: ['**/tests/**/*.spec.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.jest.json'
+    }
+  }
 };

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "rebuild:electron": "electron-rebuild -f -w better-sqlite3",
     "rebuild:all": "npm run rebuild:node && npm run rebuild:electron",
     "postinstall": "npm run rebuild:electron",
+    "pretest": "npm run rebuild:node",
     "test": "jest",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  },
+  "include": ["tests/**/*.ts", "tests/**/*.tsx"]
+}


### PR DESCRIPTION
## Summary
- add Jest-specific tsconfig extending project defaults
- configure Jest to use ts-jest and custom tsconfig
- rebuild native modules before tests and document Jest usage

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0c116830832583513cc994bc72ac