### PR TITLE
fix: update electron-rebuild dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "cross-env": "^7.0.0",
     "wait-on": "^7.0.0",
     "electron-builder": "^24.0.0",
-    "electron-rebuild": "^3.5.0",
+    "electron-rebuild": "^3.0.0",
     "@types/node": "^20.0.0",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",


### PR DESCRIPTION
## Summary
- replace invalid electron-rebuild dev dependency with a working 3.x range

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae106e5e28832596371246d5b7eda5