### PR TITLE
Refactor DATANORM importer scope and error handling

### DIFF
--- a/src/datanorm/index.ts
+++ b/src/datanorm/index.ts
@@ -1,4 +1,4 @@
-import { runImport } from './importer';
+import { runImport, type ImportResult } from './importer';
 
 export interface DatanormImportOptions {
   input: string;
@@ -8,22 +8,7 @@ export interface DatanormImportOptions {
   version?: 'v4' | 'v5' | 'auto';
 }
 
-export interface ImportResult {
-  version: 'v4' | 'v5';
-  filesProcessed: string[];
-  counts: {
-    articles: number;
-    texts: number;
-    warengruppen: number;
-    rabattgruppen: number;
-    prices: number;
-    priceTiers: number;
-    media: number;
-    sets: number;
-    errors: number;
-  };
-  reportPath: string;
-}
+export type { ImportResult };
 
 export async function importDatanorm(opts: DatanormImportOptions): Promise<ImportResult> {
   const options = { version: 'auto', dryRun: false, ...opts } as DatanormImportOptions;


### PR DESCRIPTION
## Summary
- introduce typed ImportCounts, ImportError, and ImportResult
- centralize version, counts, and errors with try/catch/finally and report writing
- export new ImportResult via datanorm index

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'jest', 'node')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae19bccd548325ba4765f787dfbcb1