### PR TITLE
refactor: fix better-sqlite3 imports

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,11 +1,12 @@
 import Database from 'better-sqlite3';
+import type { Database as DatabaseType } from 'better-sqlite3';
 import fs from 'fs';
 import path from 'path';
 import { ArticleRecord } from '../datanorm/records';
 
-let db: Database | null = null;
+let db: DatabaseType | null = null;
 
-export function getDb(dbPath = path.join(process.cwd(), 'datanorm.sqlite')): Database {
+export function getDb(dbPath = path.join(process.cwd(), 'datanorm.sqlite')): DatabaseType {
   if (!db) {
     db = new Database(dbPath);
     const schema = fs.readFileSync(path.join(__dirname, 'schema.sql'), 'utf8');

--- a/src/main/db.migrations.ts
+++ b/src/main/db.migrations.ts
@@ -1,6 +1,7 @@
-import type Database from 'better-sqlite3';
+import Database from 'better-sqlite3';
+import type { Database as DatabaseType } from 'better-sqlite3';
 
-export function ensureSchema(db: Database) {
+export function ensureSchema(db: DatabaseType) {
   db.pragma('journal_mode = WAL');
   db.pragma('foreign_keys = ON');
   db.exec(`

--- a/src/main/db.ts
+++ b/src/main/db.ts
@@ -1,4 +1,5 @@
 import Database from 'better-sqlite3';
+import type { Database as DatabaseType } from 'better-sqlite3';
 import { app } from 'electron';
 import fs from 'fs';
 import path from 'path';

--- a/src/types/better-sqlite3.d.ts
+++ b/src/types/better-sqlite3.d.ts
@@ -3,4 +3,5 @@ declare module 'better-sqlite3' {
     constructor(...args: any[]);
     [key: string]: any;
   }
+  export { Database };
 }

--- a/tests/datanorm.import.spec.ts
+++ b/tests/datanorm.import.spec.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 import iconv from 'iconv-lite';
 import Database from 'better-sqlite3';
+import type { Database as DatabaseType } from 'better-sqlite3';
 import { importDatanorm } from '../src/datanorm';
 
 type ArticleRow = { artnr: string };


### PR DESCRIPTION
## Summary
- standardize better-sqlite3 imports to default + type alias
- adjust db types to use DatabaseType
- expose Database as named export in local typings

## Testing
- `npm run typecheck`
- `npm test` *(fails: gyp ERR! configure error: 403 response downloading node headers)*

------
https://chatgpt.com/codex/tasks/task_e_68affcf47d108325acc115839751d65a