### PR TITLE
Ensure typed article IDs during Datanorm import

### DIFF
--- a/tests/datanorm.import.spec.ts
+++ b/tests/datanorm.import.spec.ts
@@ -5,8 +5,7 @@ import iconv from 'iconv-lite';
 import Database from 'better-sqlite3';
 import type { Database as DatabaseType } from 'better-sqlite3';
 import { importDatanorm } from '../src/datanorm';
-
-type ArticleRow = { artnr: string };
+import type { ArticleRow } from '../src/db';
 type LangTextRow = { langtext: string };
 type CountRow = { c: number };
 


### PR DESCRIPTION
## Summary
- add shared `ArticleRow` type in DB helpers
- fetch and type article rows after upsert for pricing, media and texts
- adjust importer test to use typed `ArticleRow`

## Testing
- `npm test -- tests/datanorm.import.spec.ts` *(fails: unable to download Node headers for better-sqlite3 rebuild)*
- `npm --ignore-scripts test -- tests/datanorm.import.spec.ts` *(fails: missing type declarations for better-sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_68b0150fdd148325ae991f500ee98f47