### PR TITLE
refactor(db): cast better-sqlite3 get results

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -6,8 +6,6 @@ import { ArticleRecord } from '../datanorm/records';
 
 export type ArticleRow = { id: number; artnr: string };
 type IdRow = { id: number };
-type WarenGruppeRow = { id: number; code: string; bezeichnung: string };
-type RabattGruppeRow = { id: number; code: string; bezeichnung: string };
 
 let db: DatabaseType | null = null;
 
@@ -39,27 +37,28 @@ export function withTransaction<T>(fn: () => T): T {
 export function upsertWarengruppe(code: { hauptgruppe: string; gruppe: string; bezeichnung: string }): number {
   const db = getDb();
   const sel = db.prepare('SELECT id FROM warengruppen WHERE hauptgruppe=? AND gruppe=?');
-  const row = sel.get<IdRow>(code.hauptgruppe, code.gruppe);
+  const row = sel.get(code.hauptgruppe, code.gruppe) as IdRow | undefined;
   if (row) {
     db.prepare('UPDATE warengruppen SET bezeichnung=? WHERE id=?').run(code.bezeichnung, row.id);
     return row.id;
   }
   const info = db
-    .prepare('INSERT INTO warengruppen (hauptgruppe,gruppe,bezeichnung) VALUES (?,?,?)')
+    .prepare('INSERT INTO warengruppen (hauptgruppe, gruppe, bezeichnung) VALUES (?,?,?)')
     .run(code.hauptgruppe, code.gruppe, code.bezeichnung);
-  const id = Number(info.lastInsertRowid);
-  return id;
+  return Number(info.lastInsertRowid);
 }
 
 export function upsertRabattgruppe(code: { nummer: string; bezeichnung: string }): number {
   const db = getDb();
-  const row = db.prepare('SELECT id FROM rabattgruppen WHERE nummer=?').get<IdRow>(code.nummer);
+  const row = db
+    .prepare('SELECT id FROM rabattgruppen WHERE nummer=?')
+    .get(code.nummer) as IdRow | undefined;
   if (row) {
     db.prepare('UPDATE rabattgruppen SET bezeichnung=? WHERE id=?').run(code.bezeichnung, row.id);
     return row.id;
   }
   const info = db
-    .prepare('INSERT INTO rabattgruppen (nummer,bezeichnung) VALUES (?,?)')
+    .prepare('INSERT INTO rabattgruppen (nummer, bezeichnung) VALUES (?,?)')
     .run(code.nummer, code.bezeichnung);
   return Number(info.lastInsertRowid);
 }
@@ -67,7 +66,7 @@ export function upsertRabattgruppe(code: { nummer: string; bezeichnung: string }
 export function upsertArticle(rec: ArticleRecord & { warengruppe_id?: number; rabattgruppe_id?: number }): ArticleRow {
   const db = getDb();
   const sel = db.prepare('SELECT id, artnr FROM articles WHERE artnr=?');
-  const row = sel.get<ArticleRow>(rec.artnr);
+  const row = sel.get(rec.artnr) as ArticleRow | undefined;
   if (row) {
     db.prepare(
       `UPDATE articles SET kurztext1=@kurztext1, kurztext2=@kurztext2, einheit=@einheit, ean=@ean, matchcode=@matchcode, warengruppe_id=@warengruppe_id, rabattgruppe_id=@rabattgruppe_id, katalogseite=@katalogseite, steuer_merker=@steuer_merker, updated_at=CURRENT_TIMESTAMP WHERE id=@id`
@@ -79,7 +78,7 @@ export function upsertArticle(rec: ArticleRecord & { warengruppe_id?: number; ra
       `INSERT INTO articles (artnr, kurztext1, kurztext2, einheit, ean, matchcode, warengruppe_id, rabattgruppe_id, katalogseite, steuer_merker) VALUES (@artnr,@kurztext1,@kurztext2,@einheit,@ean,@matchcode,@warengruppe_id,@rabattgruppe_id,@katalogseite,@steuer_merker)`
     )
     .run(rec);
-  return { id: Number(res.lastInsertRowid), artnr: rec.artnr };
+  return { id: Number(res.lastInsertRowid), artnr: rec.artnr } satisfies ArticleRow;
 }
 
 export function setArticleText(articleId: number, text: string): void {


### PR DESCRIPTION
## Summary
- cast better-sqlite3 `get` results instead of using generics
- handle undefined rows when upserting groups and articles
- return typed article rows

## Testing
- `npm run rebuild:node` *(fails: 403 response downloading node headers)*
- `npm test -- tests/datanorm.import.spec.ts` *(fails: 403 response downloading node headers)*

------
https://chatgpt.com/codex/tasks/task_e_68b0363da5d48325bf47a7594e3aa399