### PR TITLE
Fix DATANORM import writing

### DIFF
--- a/tests/datanorm.import.spec.ts
+++ b/tests/datanorm.import.spec.ts
@@ -38,12 +38,16 @@ describe('DATANORM Import', () => {
     process.chdir(dir);
     const res = await importDatanorm({ input: dir });
     expect(res.version).toBe('v5');
-    const db = new Database(path.join(dir, 'datanorm.sqlite'));
-    // better-sqlite3 typings geben .get() als unknown zurück – für TS-Strictness hier gezielt typisieren.
-    const art = db
-      .prepare('SELECT * FROM articles')
-      .get() as ArticleRow | undefined;
-    expect(art).toBeDefined();
+      const db = new Database(path.join(dir, 'datanorm.sqlite'));
+      // better-sqlite3 typings geben .get() als unknown zurück – für TS-Strictness hier gezielt typisieren.
+      const art = db
+        .prepare('SELECT * FROM articles')
+        .get() as ArticleRow | undefined;
+      const dbFile = path.join(dir, 'datanorm.sqlite');
+      console.log('DB file:', dbFile);
+      const ac = db.prepare('SELECT COUNT(*) c FROM articles').get() as CountRow | undefined;
+      console.log('articles count after import:', ac?.c);
+      expect(art).toBeDefined();
     expect(art!.artnr).toBe('ART1');
     const txt = db
       .prepare('SELECT langtext FROM article_texts')
@@ -83,11 +87,15 @@ describe('DATANORM Import', () => {
     process.chdir(dir);
     const res = await importDatanorm({ input: dir });
     expect(res.version).toBe('v4');
-    const db = new Database(path.join(dir, 'datanorm.sqlite'));
-    const art = db
-      .prepare('SELECT * FROM articles')
-      .get() as ArticleRow | undefined;
-    expect(art).toBeDefined();
+      const db = new Database(path.join(dir, 'datanorm.sqlite'));
+      const art = db
+        .prepare('SELECT * FROM articles')
+        .get() as ArticleRow | undefined;
+      const dbFile = path.join(dir, 'datanorm.sqlite');
+      console.log('DB file:', dbFile);
+      const ac = db.prepare('SELECT COUNT(*) c FROM articles').get() as CountRow | undefined;
+      console.log('articles count after import:', ac?.c);
+      expect(art).toBeDefined();
     expect(art!.artnr).toBe('ART2');
   });
 


### PR DESCRIPTION
## Summary
- ensure DB path and schema are derived from input dir and close correctly
- wrap DATANORM import in a transaction, return table counts and db path
- add debugging logs for article upsert and text inserts; enhance tests with DB diagnostics

## Testing
- `npm test` *(fails: Error: 403 response downloading https://nodejs.org/download/release/v20.19.4/node-v20.19.4-headers.tar.gz)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b0445f5f448325aa0d69378d4dbbcb