### PR TITLE
Use local Node headers for Jest tests

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+nodedir=C:\node-headers\v20.17.0

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
     "rebuild:electron": "electron-rebuild -f -w better-sqlite3",
     "rebuild:all": "npm run rebuild:node && npm run rebuild:electron",
     "postinstall": "npm run rebuild:electron",
-    "pretest": "npm run rebuild:node",
-    "test": "jest",
+    "pretest": "node -e \"process.exit(0)\"",
+    "test": "ts-node -T scripts/run-tests-with-local-headers.ts",
+    "test:unit": "ts-node -T scripts/run-tests-with-local-headers.ts",
+    "test:file": "ts-node -T scripts/run-tests-with-local-headers.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
@@ -43,7 +45,7 @@
   },
   "devDependencies": {
     "typescript": "^5.0.0",
-    "ts-node": "^10.9.1",
+    "ts-node": "^10.9.2",
     "vite": "^5.0.0",
     "concurrently": "^8.0.0",
     "cross-env": "^7.0.0",

--- a/scripts/run-tests-with-local-headers.ts
+++ b/scripts/run-tests-with-local-headers.ts
@@ -1,0 +1,55 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import * as path from 'node:path';
+
+function versionTag() {
+  // z.B. "v20.17.0"
+  return process.version.replace(/^v?/, 'v');
+}
+
+function headersRoot() {
+  return path.join('C:\\', 'node-headers', versionTag());
+}
+
+function assertHeaders() {
+  const include = path.join(headersRoot(), 'include', 'node', 'node_api.h');
+  const lib = path.join(headersRoot(), 'Release', 'node.lib');
+  const missing: string[] = [];
+  if (!existsSync(include)) missing.push(include);
+  if (!existsSync(lib)) missing.push(lib);
+  if (missing.length) {
+    console.error('Fehlende lokale Node-Header/Lib:\n - ' + missing.join('\n - '));
+    process.exit(1);
+  }
+}
+
+function run(cmd: string, args: string[], env: NodeJS.ProcessEnv = {}) {
+  const child = spawnSync(cmd, args, {
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+    env: { ...process.env, ...env },
+  });
+  if (child.status !== 0) {
+    process.exit(child.status ?? 1);
+  }
+}
+
+function main() {
+  const nodedir = headersRoot();
+  assertHeaders();
+
+  // 1) rebuild better-sqlite3 strikt gegen lokale Headers
+  run('npm', ['rebuild', 'better-sqlite3', '--build-from-source', '--loglevel', 'verbose'], {
+    npm_config_nodedir: nodedir,
+    nodedir,
+  });
+
+  // 2) Jest starten (Args durchreichen)
+  const args = process.argv.slice(2);
+  run('node', [path.join('node_modules', 'jest', 'bin', 'jest.js'), ...args], {
+    npm_config_nodedir: nodedir,
+    nodedir,
+  });
+}
+
+main();


### PR DESCRIPTION
## Summary
- add project `.npmrc` setting a default `nodedir`
- add TypeScript test runner rebuilding `better-sqlite3` against local headers before running Jest
- wire package scripts to the new runner and bump `ts-node`

## Testing
- `npm run test -- tests/datanorm.import.spec.ts` *(fails: Fehlende lokale Node-Header/Lib)*

------
https://chatgpt.com/codex/tasks/task_e_68b04a19400c832592058d7ba595a007