### PR TITLE
chore: hide barcode text and fix label layout

### DIFF
--- a/src/main/labels/pdf.ts
+++ b/src/main/labels/pdf.ts
@@ -42,13 +42,9 @@ async function renderBarcode(artnr: string): Promise<Buffer> {
   const opts = {
     bcid,
     text: code,
-    alttext: trimmed,
     scale: 2,
     height: 20,
-    includetext: true,
-    textxalign: 'center' as const,
-    textfont: 'Helvetica',
-    textsize: 14,
+    includetext: false,
   };
   try {
     return await bwipjs.toBuffer(opts);

--- a/src/renderer/lib/labels.ts
+++ b/src/renderer/lib/labels.ts
@@ -61,15 +61,11 @@ export async function renderBarcodePng(
     background: '#fff',
     width: Math.max(1, Math.floor(pxW / 180)),
     height: Math.max(30, Math.floor(pxH * 0.65)),
-    displayValue: true,
-    text: trimmed,
-    font: 'Helvetica',
-    fontSize: 14,
-    textMargin: 4,
-    textAlign: 'center',
-    margin: 10,
+    displayValue: false,
+    margin: 0,
     marginTop: 0,
     marginBottom: 0,
+    fontSize: 0,
   };
 
   JsBarcode(canvas, code, opts);

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -7,8 +7,12 @@ body {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 4px;
+  gap: 4mm;
   padding-left: 3mm;
+  padding-bottom: 3mm;
+  min-height: 45mm;
+  break-inside: avoid;
+  page-break-inside: avoid;
 }
 
 .label__sku,
@@ -28,7 +32,8 @@ body {
 }
 
 .label__barcode {
-  margin-top: 12px;
+  margin-top: 0;
+  margin-bottom: 3mm;
   position: static;
   overflow: visible;
 }
@@ -47,13 +52,8 @@ body {
 }
 
 .label__footer {
-  margin-top: 4px;
-  font-size: 8px;
-}
-
-@media print {
-  .label {
-    margin-bottom: 2cm;
-    page-break-inside: avoid;
-  }
+  margin-top: 2mm;
+  font-size: 10pt;
+  line-height: 1.2;
+  white-space: nowrap;
 }

--- a/tests/barcode.spec.ts
+++ b/tests/barcode.spec.ts
@@ -19,7 +19,7 @@ test('renders CODE128 for alphanumeric article numbers', async () => {
   const [canvas, code, opts] = mocked.mock.calls[0];
   expect(code).toBe('abc123');
   expect(opts.format).toBe('CODE128');
-  expect(opts.text).toBe('abc123');
+  expect(opts.displayValue).toBe(false);
 });
 
 test('renders EAN13 for 13-digit numbers', async () => {
@@ -27,7 +27,7 @@ test('renders EAN13 for 13-digit numbers', async () => {
   const [canvas, code, opts] = mocked.mock.calls[0];
   expect(code).toBe('0000000123457');
   expect(opts.format).toBe('EAN13');
-  expect(opts.text).toBe('0000000123457');
+  expect(opts.displayValue).toBe(false);
 });
 
 test('falls back to CODE128 for short numbers', async () => {
@@ -35,4 +35,5 @@ test('falls back to CODE128 for short numbers', async () => {
   const [canvas, code, opts] = mocked.mock.calls[0];
   expect(code).toBe('000123');
   expect(opts.format).toBe('CODE128');
+  expect(opts.displayValue).toBe(false);
 });


### PR DESCRIPTION
## Summary
- suppress human-readable barcode text in JsBarcode and bwip-js rendering
- refine label CSS to add spacing and prevent footers from overlapping
- update unit tests to reflect new barcode options

## Testing
- `npm test` *(fails: Fehlende lokale Node-Header/Lib)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b19ce6773083258e4da03a6c5693b9