### PR TITLE
feat: add spacing between printed label columns

### DIFF
--- a/src/renderer/components/PreviewPane.tsx
+++ b/src/renderer/components/PreviewPane.tsx
@@ -18,7 +18,9 @@ const PreviewPane: React.FC<Props> = ({ opts }) => {
   };
   return (
     <div>
-      <LabelPreview opts={opts} />
+      <div className="labels-grid">
+        <LabelPreview opts={opts} />
+      </div>
       <Button onClick={generate}>PDF erzeugen</Button>
     </div>
   );

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -8,9 +8,9 @@ body {
   flex-direction: column;
   align-items: flex-start;
   gap: 4mm;
-  padding-left: 3mm;
-  padding-bottom: 3mm;
-  min-height: 45mm;
+  box-sizing: border-box;
+  padding: 3mm 2mm;
+  min-height: 46mm;
   break-inside: avoid;
   page-break-inside: avoid;
 }
@@ -52,8 +52,23 @@ body {
 }
 
 .label__footer {
-  margin-top: 2mm;
+  margin-top: auto;
   font-size: 10pt;
   line-height: 1.2;
   white-space: nowrap;
+}
+
+@media print {
+  @page {
+    margin: 8mm;
+  }
+
+  .labels-grid,
+  .etiketten-grid,
+  .labels-page {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    column-gap: 15mm;
+    row-gap: 6mm;
+  }
 }


### PR DESCRIPTION
## Summary
- ensure label preview page renders inside grid container
- add print styles with column gap between label columns

## Testing
- `npm test` *(fails: Fehlende lokale Node-Header/Lib)*

------
https://chatgpt.com/codex/tasks/task_e_68b1aa8283a88325a71ffbf0180ff158