### PR TITLE
Increase printed label row spacing

### DIFF
--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -69,6 +69,6 @@ body {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     column-gap: 15mm;
-    row-gap: 6mm;
+    row-gap: 12mm;
   }
 }


### PR DESCRIPTION
## Summary
- increase row-gap in print styles to 12mm for better separation between label rows

## Testing
- `npm test` *(fails: Fehlende lokale Node-Header/Lib)*

------
https://chatgpt.com/codex/tasks/task_e_68b5678211bc832595c71cc6a0f9cee1