### PR TITLE
feat: add label layout formatting dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "electron": "^30.0.0",
     "electron-updater": "^6.1.1",
+    "electron-store": "^10.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.0.0",

--- a/src/renderer/components/LabelLayoutDialog.tsx
+++ b/src/renderer/components/LabelLayoutDialog.tsx
@@ -1,0 +1,125 @@
+import React, { useState } from 'react';
+import {
+  getLabelLayout,
+  setLabelLayout,
+  LabelLayoutSettings,
+} from '../lib/labelLayoutStore';
+
+type Props = { open: boolean; onClose: () => void };
+
+export default function LabelLayoutDialog({ open, onClose }: Props) {
+  const [v, setV] = useState<LabelLayoutSettings>(getLabelLayout());
+  if (!open) return null;
+
+  const update = <K extends keyof LabelLayoutSettings>(
+    key: K,
+    value: LabelLayoutSettings[K],
+  ) => setV({ ...v, [key]: value });
+
+  return (
+    <div className="modal-backdrop">
+      <div className="modal">
+        <h2>Etiketten formatieren</h2>
+        <div className="grid-2">
+          <fieldset>
+            <legend>Druckabstand (Seitenränder)</legend>
+            <label>
+              Oben (mm)
+              <input
+                type="number"
+                value={v.pageMargin.top}
+                onChange={e =>
+                  update('pageMargin', { ...v.pageMargin, top: +e.target.value })
+                }
+              />
+            </label>
+            <label>
+              Unten (mm)
+              <input
+                type="number"
+                value={v.pageMargin.bottom}
+                onChange={e =>
+                  update('pageMargin', {
+                    ...v.pageMargin,
+                    bottom: +e.target.value,
+                  })
+                }
+              />
+            </label>
+            <label>
+              Links (mm)
+              <input
+                type="number"
+                value={v.pageMargin.left}
+                onChange={e =>
+                  update('pageMargin', { ...v.pageMargin, left: +e.target.value })
+                }
+              />
+            </label>
+            <label>
+              Rechts (mm)
+              <input
+                type="number"
+                value={v.pageMargin.right}
+                onChange={e =>
+                  update('pageMargin', { ...v.pageMargin, right: +e.target.value })
+                }
+              />
+            </label>
+          </fieldset>
+
+          <fieldset>
+            <legend>Abstand zwischen Etiketten</legend>
+            <label>
+              Horizontal (mm)
+              <input
+                type="number"
+                value={v.gap.col}
+                onChange={e => update('gap', { ...v.gap, col: +e.target.value })}
+              />
+            </label>
+            <label>
+              Vertikal (mm)
+              <input
+                type="number"
+                value={v.gap.row}
+                onChange={e => update('gap', { ...v.gap, row: +e.target.value })}
+              />
+            </label>
+            <label>
+              Footer-Abstand oben (mm)
+              <input
+                type="number"
+                value={v.footerMarginTop}
+                onChange={e => update('footerMarginTop', +e.target.value as any)}
+              />
+            </label>
+            <label className="chk">
+              <input
+                type="checkbox"
+                checked={v.hideArticleNumberBelowBarcode}
+                onChange={e =>
+                  update('hideArticleNumberBelowBarcode', e.target.checked)
+                }
+              />
+              Artikelnummer unter Barcode ausblenden
+            </label>
+          </fieldset>
+        </div>
+
+        <div className="modal-actions">
+          <button onClick={onClose}>Abbrechen</button>
+          <button
+            className="primary"
+            onClick={() => {
+              setLabelLayout(v);
+              onClose();
+            }}
+          >
+            Speichern
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/LabelPreview.tsx
+++ b/src/renderer/components/LabelPreview.tsx
@@ -19,6 +19,9 @@ const LabelPreview: React.FC<Props> = ({ opts }) => {
           </svg>
         </div>
       )}
+      {opts.showArticleNumber && (
+        <div className="label__barcode-number-below">12345</div>
+      )}
       <div className="label__footer">Elektro Brunner Johann</div>
     </div>
   );

--- a/src/renderer/components/PreviewPane.tsx
+++ b/src/renderer/components/PreviewPane.tsx
@@ -1,13 +1,19 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import LabelPreview from './LabelPreview';
+import LabelLayoutDialog from './LabelLayoutDialog';
 import { Button } from '@fluentui/react-components';
 import type { LabelOptions } from './LabelOptionsPane';
+import { applyLayoutCssVariables } from '../lib/labelLayoutStore';
 
 interface Props {
   opts: LabelOptions;
 }
 
 const PreviewPane: React.FC<Props> = ({ opts }) => {
+  const [open, setOpen] = useState(false);
+  useEffect(() => {
+    applyLayoutCssVariables();
+  }, []);
   const generate = async () => {
     const cart = (await window.bridge?.cart?.get?.()) || [];
     if (!cart.length) return;
@@ -17,11 +23,15 @@ const PreviewPane: React.FC<Props> = ({ opts }) => {
     await window.bridge?.shell?.open?.(res.pdfPath);
   };
   return (
-    <div>
+    <div className="labels-page">
+      <div className="toolbar">
+        <button onClick={() => setOpen(true)}>Etiketten formatieren</button>
+        <Button onClick={generate}>PDF erzeugen</Button>
+      </div>
       <div className="labels-grid">
         <LabelPreview opts={opts} />
       </div>
-      <Button onClick={generate}>PDF erzeugen</Button>
+      <LabelLayoutDialog open={open} onClose={() => setOpen(false)} />
     </div>
   );
 };

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -2,9 +2,12 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import './styles/global.css';
+import { applyLayoutCssVariables } from './lib/labelLayoutStore';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
   root.render(<App />);
 }
+
+applyLayoutCssVariables();

--- a/src/renderer/lib/labelLayoutStore.ts
+++ b/src/renderer/lib/labelLayoutStore.ts
@@ -1,0 +1,49 @@
+import Store from 'electron-store';
+
+export type LabelLayoutSettings = {
+  pageMargin: { top: number; right: number; bottom: number; left: number };
+  gap: { row: number; col: number };
+  hideArticleNumberBelowBarcode: boolean;
+  footerMarginTop: number;
+};
+
+const defaults: LabelLayoutSettings = {
+  pageMargin: { top: 8, right: 8, bottom: 8, left: 8 },
+  gap: { row: 10, col: 10 },
+  hideArticleNumberBelowBarcode: true,
+  footerMarginTop: 6,
+};
+
+const store = new Store<LabelLayoutSettings>({ name: 'label-layout', defaults });
+
+export function getLabelLayout(): LabelLayoutSettings {
+  return {
+    pageMargin: store.get('pageMargin', defaults.pageMargin),
+    gap: store.get('gap', defaults.gap),
+    hideArticleNumberBelowBarcode: store.get(
+      'hideArticleNumberBelowBarcode',
+      defaults.hideArticleNumberBelowBarcode,
+    ),
+    footerMarginTop: store.get('footerMarginTop', defaults.footerMarginTop),
+  };
+}
+
+export function setLabelLayout(next: LabelLayoutSettings) {
+  store.set(next);
+  applyLayoutCssVariables(next);
+}
+
+export function applyLayoutCssVariables(s: LabelLayoutSettings = getLabelLayout()) {
+  const r = document.documentElement;
+  r.style.setProperty('--page-margin-top-mm', `${s.pageMargin.top}mm`);
+  r.style.setProperty('--page-margin-right-mm', `${s.pageMargin.right}mm`);
+  r.style.setProperty('--page-margin-bottom-mm', `${s.pageMargin.bottom}mm`);
+  r.style.setProperty('--page-margin-left-mm', `${s.pageMargin.left}mm`);
+  r.style.setProperty('--row-gap-mm', `${s.gap.row}mm`);
+  r.style.setProperty('--col-gap-mm', `${s.gap.col}mm`);
+  r.style.setProperty('--footer-margin-top-mm', `${s.footerMarginTop}mm`);
+  r.style.setProperty(
+    '--label-hide-article-number',
+    s.hideArticleNumberBelowBarcode ? 'none' : 'block',
+  );
+}

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -3,6 +3,17 @@ body {
   font-family: sans-serif;
 }
 
+:root {
+  --page-margin-top-mm: 8mm;
+  --page-margin-right-mm: 8mm;
+  --page-margin-bottom-mm: 8mm;
+  --page-margin-left-mm: 8mm;
+  --row-gap-mm: 10mm;
+  --col-gap-mm: 10mm;
+  --footer-margin-top-mm: 6mm;
+  --label-hide-article-number: none;
+}
+
 .label {
   display: flex;
   flex-direction: column;
@@ -58,9 +69,73 @@ body {
   white-space: nowrap;
 }
 
+.label__barcode-number-below {
+  display: var(--label-hide-article-number);
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.modal {
+  background: #fff;
+  max-width: 720px;
+  width: 96%;
+  padding: 16px 20px;
+  border-radius: 14px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.25);
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+fieldset {
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 12px;
+}
+fieldset > label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+.chk {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 12px;
+}
+.primary {
+  background: #1f6feb;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 14px;
+}
+
+.labels-page .toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin: 8px 0 14px 0;
+  gap: 8px;
+}
+
 @media print {
   @page {
-    margin: 8mm;
+    margin: var(--page-margin-top-mm) var(--page-margin-right-mm)
+      var(--page-margin-bottom-mm) var(--page-margin-left-mm);
   }
 
   .labels-grid,
@@ -68,7 +143,15 @@ body {
   .labels-page {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
-    column-gap: 15mm;
-    row-gap: 12mm;
+    row-gap: var(--row-gap-mm);
+    column-gap: var(--col-gap-mm);
+  }
+
+  .label__footer {
+    margin-top: var(--footer-margin-top-mm) !important;
+  }
+
+  .label__barcode-number-below {
+    display: var(--label-hide-article-number) !important;
   }
 }

--- a/src/types/electron-store.d.ts
+++ b/src/types/electron-store.d.ts
@@ -1,0 +1,8 @@
+declare module 'electron-store' {
+  export default class Store<T = any> {
+    constructor(options?: any);
+    get<K extends keyof T>(key: K, defaultValue?: T[K]): T[K];
+    set(object: T): void;
+    set<K extends keyof T>(key: K, value: T[K]): void;
+  }
+}


### PR DESCRIPTION
## Summary
- add persistent label layout store based on electron-store
- allow adjusting margins, label gaps, footer spacing and hiding article number through a modal dialog
- apply CSS variables for print layout and integrate formatting button on preview page

## Testing
- `npm test` *(fails: Fehlende lokale Node-Header/Lib)*
- `npm run typecheck`

## Notes
- `npm install electron-store` failed with 403 Forbidden; dependency may be missing at runtime

------
https://chatgpt.com/codex/tasks/task_e_68b56d72ac1483259f39eeb4b9587125