### PR TITLE
fix: ensure electron-store available

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "electron": "^30.0.0",
     "electron-updater": "^6.1.1",
-    "electron-store": "^10.0.0",
+    "electron-store": "^8.1.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.0.0",

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -1,4 +1,14 @@
-import Store from 'electron-store';
+import type ElectronStore from 'electron-store';
+
+let ElectronStoreCtor: typeof ElectronStore;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  ElectronStoreCtor = require('electron-store');
+} catch {
+  throw new Error(
+    "electron-store nicht installiert – bitte 'npm i electron-store@^8' ausführen."
+  );
+}
 
 export type SettingsSchema = {
   pageMargin: { top: number; right: number; bottom: number; left: number };
@@ -16,11 +26,11 @@ const defaults: SettingsSchema = {
   rows: 8,
 };
 
-let store: Store<SettingsSchema>;
+let store: ElectronStore<SettingsSchema>;
 
 function getStore() {
   if (!store) {
-    store = new Store<SettingsSchema>({ name: 'settings', defaults });
+    store = new ElectronStoreCtor<SettingsSchema>({ name: 'settings', defaults });
 
     // Migration: ensure all default keys exist
     for (const [key, value] of Object.entries(defaults)) {


### PR DESCRIPTION
## Summary
- pin electron-store as runtime dependency for CommonJS main process
- load electron-store in main with explicit error if module is missing

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/electron-store)*
- `npm test` *(fails: Fehlende lokale Node-Header/Lib)*
- `npm run dev` *(fails: electron binary missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b58a2fd4b08325baa24e3e60f76585