### PR TITLE
fix: import electron-store in main process

### DIFF
--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -1,14 +1,4 @@
-import type ElectronStore from 'electron-store';
-
-let ElectronStoreCtor: typeof ElectronStore;
-try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  ElectronStoreCtor = require('electron-store');
-} catch {
-  throw new Error(
-    "electron-store nicht installiert – bitte 'npm i electron-store@^8' ausführen."
-  );
-}
+import Store from 'electron-store';
 
 export type SettingsSchema = {
   pageMargin: { top: number; right: number; bottom: number; left: number };
@@ -26,11 +16,11 @@ const defaults: SettingsSchema = {
   rows: 8,
 };
 
-let store: ElectronStore<SettingsSchema>;
+let store: Store<SettingsSchema>;
 
 function getStore() {
   if (!store) {
-    store = new ElectronStoreCtor<SettingsSchema>({ name: 'settings', defaults });
+    store = new Store<SettingsSchema>({ name: 'settings', defaults });
 
     // Migration: ensure all default keys exist
     for (const [key, value] of Object.entries(defaults)) {


### PR DESCRIPTION
## Summary
- import electron-store directly in settings module so the main process uses runtime dependency

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/electron-store)*
- `npm run dev` *(fails: /workspace/etiketten/node_modules/electron/dist/electron: error while loading shared libraries: libatk-1.0.so.0: cannot open shared object file: No such file or directory)*
- `npm test` *(fails: Missing local Node headers/libs)*

------
https://chatgpt.com/codex/tasks/task_e_68b58c9982f48325b80d810a9c2ddd57