### PR TITLE
feat: add PDF label printing and import wizard

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "iconv-lite": "^0.6.3",
     "zod": "^3.22.0",
     "jsbarcode": "^3.11.5",
-    "jspdf": "^2.5.1"
+    "jspdf": "^2.5.1",
+    "papaparse": "^5.4.1",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "typescript": "^5.0.0",

--- a/src/main/ipc/articles.ts
+++ b/src/main/ipc/articles.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron';
-import { searchArticles } from '../db';
+import { searchArticles, upsertArticles } from '../db';
 import { IPC_CHANNELS, SearchPayloadSchema, SearchResultSchema } from '../../shared/ipc';
 
 export function registerArticlesHandlers() {
@@ -11,5 +11,9 @@ export function registerArticlesHandlers() {
       offset: page * pageSize,
     });
     return SearchResultSchema.parse({ items, total });
+  });
+
+  ipcMain.handle('articles:upsertMany', (_e, items) => {
+    return upsertArticles(items || []);
   });
 }

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -18,12 +18,14 @@ import { registerCartHandlers } from './cart';
 import { registerLabelsHandlers } from './labels';
 import { registerShellHandlers } from './shell';
 import { registerMediaHandlers } from './media';
+import { registerArticlesHandlers } from './articles';
 
 export function registerIpcHandlers() {
   registerCartHandlers();
   registerLabelsHandlers();
   registerShellHandlers();
   registerMediaHandlers();
+  registerArticlesHandlers();
 
   ipcMain.handle('datanorm:import', async (_e, { filePath, mapping, categoryId }) => {
     const res = await importDatanormFile({ filePath, mapping, categoryId });

--- a/src/main/ipc/print.ts
+++ b/src/main/ipc/print.ts
@@ -1,0 +1,55 @@
+import { BrowserWindow, dialog, ipcMain } from 'electron';
+
+type PrintPayload = {
+  jobName: string;
+  html: string;
+  pageSize: 'A4' | 'Letter';
+  marginsMM: { top: number; right: number; bottom: number; left: number };
+  saveDialog?: boolean;
+  defaultPath?: string;
+};
+
+ipcMain.handle('print:labelsToPDF', async (_e, payload: PrintPayload) => {
+  try {
+    const { jobName, html, pageSize = 'A4', marginsMM, saveDialog = true, defaultPath } = payload;
+
+    const win = new BrowserWindow({
+      show: false,
+      webPreferences: {
+        backgroundThrottling: false,
+      },
+    });
+
+    const b64 = Buffer.from(html).toString('base64');
+    await win.loadURL(`data:text/html;base64,${b64}`);
+    await new Promise<void>((resolve) => {
+      win.webContents.on('did-finish-load', () => resolve());
+    });
+
+    const pdfBuffer = await win.webContents.printToPDF({
+      pageSize,
+      printBackground: true,
+    } as any);
+
+    if (saveDialog !== false) {
+      const { filePath, canceled } = await dialog.showSaveDialog(win, {
+        title: jobName,
+        defaultPath,
+        filters: [{ name: 'PDF', extensions: ['pdf'] }],
+      });
+      if (!canceled && filePath) {
+        const fs = await import('fs');
+        fs.writeFileSync(filePath, pdfBuffer);
+        win.destroy();
+        return { ok: true, path: filePath };
+      }
+      win.destroy();
+      return { ok: false, error: 'canceled' };
+    }
+    win.destroy();
+    return { ok: true, dataBase64: pdfBuffer.toString('base64') };
+  } catch (err: any) {
+    return { ok: false, error: String(err?.message || err) };
+  }
+});
+

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow } from 'electron';
 import path from 'path';
+import './ipc/print';
 
 app.setName('Etiketten');
 const appData = app.getPath('appData');

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -57,6 +57,19 @@ const api = {
     getAll: () => ipcRenderer.invoke('settings:get'),
     reset: () => ipcRenderer.invoke('settings:reset'),
   },
+  print: {
+    labelsToPDF: (payload: {
+      jobName: string;
+      html: string;
+      pageSize?: 'A4' | 'Letter';
+      marginsMM: { top: number; right: number; bottom: number; left: number };
+      saveDialog?: boolean;
+      defaultPath?: string;
+    }) => ipcRenderer.invoke('print:labelsToPDF', payload),
+  },
+  articles: {
+    upsertMany: (items: any[]) => ipcRenderer.invoke('articles:upsertMany', items),
+  },
 };
 
 try {

--- a/src/renderer/components/ArticleSearch.tsx
+++ b/src/renderer/components/ArticleSearch.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Button, Input, Checkbox } from '@fluentui/react-components';
 import CategoryManager from './CategoryManager';
+import ImportWizard from './ImportWizard';
 import { z } from 'zod';
 import { generateLabelsPdf } from '../lib/labelsPdf';
 import type { LabelConfig } from '../lib/labels';
@@ -30,6 +31,7 @@ const ArticleSearch: React.FC = () => {
     const [searchCategory, setSearchCategory] = useState<number | undefined>();
     const [newCategoryId, setNewCategoryId] = useState<number | undefined>();
     const [catManagerOpen, setCatManagerOpen] = useState(false);
+    const [importOpen, setImportOpen] = useState(false);
 
     const templates: Record<string, Partial<LabelConfig>> = {
       'a4-3x8': {},
@@ -629,6 +631,9 @@ const ArticleSearch: React.FC = () => {
                 <div style={{ display: 'flex', gap: '8px' }}>
                   <Button onClick={onPdf}>PDF-Etiketten erzeugen</Button>
                   <Button onClick={() => setCart([])}>Warenkorb leeren</Button>
+                  <Button onClick={() => setImportOpen(true)}>
+                    Importieren (CSV/XLSX/TXT)
+                  </Button>
                 </div>
               </div>
             )}
@@ -641,6 +646,7 @@ const ArticleSearch: React.FC = () => {
           onClose={() => setCatManagerOpen(false)}
         />
       )}
+      {importOpen && <ImportWizard open={importOpen} onClose={() => setImportOpen(false)} />}
     </>
   );
 };

--- a/src/renderer/components/ImportWizard.tsx
+++ b/src/renderer/components/ImportWizard.tsx
@@ -1,0 +1,103 @@
+import React, { useState } from 'react';
+import { parseFile } from '../lib/import/parsers';
+import { applyMapping, Mapping } from '../lib/import/applyMapping';
+
+const targetFields = [
+  { key: 'artikelnummer', label: 'Artikelnummer', required: true },
+  { key: 'ean', label: 'EAN' },
+  { key: 'kurztext', label: 'Kurztext' },
+  { key: 'preis', label: 'Preis' },
+  { key: 'einheit', label: 'Einheit' },
+];
+
+type Props = { open: boolean; onClose: () => void };
+
+export const ImportWizard: React.FC<Props> = ({ open, onClose }) => {
+  const [step, setStep] = useState(1);
+  const [file, setFile] = useState<File | null>(null);
+  const [headers, setHeaders] = useState<string[]>([]);
+  const [rows, setRows] = useState<any[]>([]);
+  const [mapping, setMapping] = useState<Mapping>({});
+  const [error, setError] = useState<string | null>(null);
+
+  const handleFile = async (f: File) => {
+    const parsed = await parseFile(f);
+    setHeaders(parsed.headers);
+    setRows(parsed.rows.slice(0, 100));
+    setFile(f);
+    setStep(2);
+  };
+
+  const startImport = async () => {
+    const items = applyMapping({ rows, headers, mapping });
+    if (!items.length) {
+      setError('Keine gültigen Daten gefunden');
+      return;
+    }
+    await window.api.articles.upsertMany(items as any);
+    onClose();
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="modal-backdrop">
+      <div className="modal">
+        <h2>Import</h2>
+        {step === 1 && (
+          <div>
+            <input
+              type="file"
+              accept=".csv,.txt,.tsv,.xlsx,.xls"
+              onChange={(e) => {
+                const f = e.target.files?.[0];
+                if (f) void handleFile(f);
+              }}
+            />
+          </div>
+        )}
+        {step === 2 && (
+          <div>
+            <table>
+              <tbody>
+                {targetFields.map((tf) => (
+                  <tr key={tf.key}>
+                    <td>{tf.label}</td>
+                    <td>
+                      <select
+                        value={mapping[tf.key] || ''}
+                        onChange={(e) =>
+                          setMapping({ ...mapping, [tf.key]: e.target.value })
+                        }
+                      >
+                        <option value="">--</option>
+                        {headers.map((h) => (
+                          <option key={h} value={h}>
+                            {h}
+                          </option>
+                        ))}
+                      </select>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {error && <div className="error">{error}</div>}
+            <div className="modal-actions">
+              <button onClick={() => setStep(1)}>Zurück</button>
+              <button
+                className="primary"
+                onClick={startImport}
+              >
+                Import starten
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ImportWizard;
+

--- a/src/renderer/components/LabelLayoutDialog.tsx
+++ b/src/renderer/components/LabelLayoutDialog.tsx
@@ -154,6 +154,23 @@ export default function LabelLayoutDialog({ open, onClose }: Props) {
               />
             </label>
           </fieldset>
+
+          <fieldset>
+            <legend>Barcode</legend>
+            <label>
+              Höhe (mm)
+              <input
+                type="number"
+                value={v.barcodeHeightMM ?? 18}
+                onChange={e =>
+                  setV({
+                    ...v,
+                    barcodeHeightMM: +e.target.value,
+                  })
+                }
+              />
+            </label>
+          </fieldset>
         </div>
 
         <div className="modal-actions">

--- a/src/renderer/lib/import/applyMapping.ts
+++ b/src/renderer/lib/import/applyMapping.ts
@@ -1,0 +1,32 @@
+export type Mapping = Record<string, string>;
+
+const normalizePrice = (v: any): number | null => {
+  if (v == null) return null;
+  const s = String(v).replace(',', '.');
+  const num = parseFloat(s);
+  return isNaN(num) ? null : num;
+};
+
+const isValidEan = (ean: string): boolean => /^(\d{8}|\d{12,13})$/.test(ean);
+
+export function applyMapping({ rows, headers, mapping }: { rows: any[]; headers: string[]; mapping: Mapping }) {
+  const idx: Record<string, number> = {};
+  headers.forEach((h, i) => (idx[h] = i));
+  return rows
+    .map((r) => {
+      const get = (field: string) => r[idx[mapping[field]] ?? -1];
+      const articleNumber = String(get('artikelnummer') ?? '').trim();
+      if (!articleNumber) return null;
+      const eanRaw = String(get('ean') ?? '').trim();
+      const ean = isValidEan(eanRaw) ? eanRaw : undefined;
+      return {
+        articleNumber,
+        ean,
+        name: String(get('kurztext') ?? '').trim(),
+        price: normalizePrice(get('preis')), 
+        unit: String(get('einheit') ?? '').trim() || null,
+      };
+    })
+    .filter(Boolean);
+}
+

--- a/src/renderer/lib/import/parsers.ts
+++ b/src/renderer/lib/import/parsers.ts
@@ -1,0 +1,21 @@
+import Papa from 'papaparse';
+import * as XLSX from 'xlsx';
+
+export async function parseFile(file: File): Promise<{ headers: string[]; rows: any[]; dialect: { delimiter: string; quoteChar?: string; hasHeader: boolean } }> {
+  const name = file.name.toLowerCase();
+  if (name.endsWith('.xlsx') || name.endsWith('.xls')) {
+    const buf = await file.arrayBuffer();
+    const wb = XLSX.read(buf, { type: 'array' });
+    const sheet = wb.Sheets[wb.SheetNames[0]];
+    const rows = XLSX.utils.sheet_to_json<any[]>(sheet, { header: 1, raw: false });
+    const headers = rows.shift() as string[];
+    return { headers, rows: rows as any[], dialect: { delimiter: ',', hasHeader: true } };
+  }
+
+  // CSV/TXT
+  const text = await file.text();
+  const parsed = Papa.parse(text, { dynamicTyping: true, skipEmptyLines: true, delimiter: Papa.parse(text, { preview: 1 }).meta.delimiter });
+  const [headers, ...rows] = parsed.data as any[];
+  return { headers, rows, dialect: { delimiter: parsed.meta.delimiter || ',', hasHeader: true } };
+}
+

--- a/src/renderer/lib/labelLayoutStore.ts
+++ b/src/renderer/lib/labelLayoutStore.ts
@@ -4,6 +4,7 @@ export type Layout = {
   spacing: { horizontal: number; vertical: number };
   columns: number;
   rows: number;
+  barcodeHeightMM?: number;
 };
 
 export const defaultLayout: Layout = {
@@ -12,6 +13,7 @@ export const defaultLayout: Layout = {
   spacing: { horizontal: 4, vertical: 8 },
   columns: 3,
   rows: 8,
+  barcodeHeightMM: 18,
 };
 
 async function ensureLayout(): Promise<Layout> {
@@ -22,6 +24,7 @@ async function ensureLayout(): Promise<Layout> {
     spacing: { ...defaultLayout.spacing, ...(data.spacing as any) },
     columns: (data.columns as number) ?? defaultLayout.columns,
     rows: (data.rows as number) ?? defaultLayout.rows,
+    barcodeHeightMM: (data.barcodeHeightMM as number) ?? defaultLayout.barcodeHeightMM,
   };
 }
 
@@ -52,4 +55,7 @@ export async function applyLayoutCssVariables(layout?: Layout): Promise<void> {
   r.style.setProperty('--spacing-vertical-mm', `${s.spacing.vertical}mm`);
   r.style.setProperty('--label-columns', String(s.columns));
   r.style.setProperty('--label-rows', String(s.rows));
+  if (s.barcodeHeightMM != null) {
+    r.style.setProperty('--barcode-height-mm', `${s.barcodeHeightMM}mm`);
+  }
 }

--- a/src/renderer/print/LabelSheet.tsx
+++ b/src/renderer/print/LabelSheet.tsx
@@ -1,0 +1,47 @@
+import JsBarcode from 'jsbarcode';
+
+export type LayoutSettings = {
+  pageMargin: { top: number; right: number; bottom: number; left: number };
+  labelSize: { width: number; height: number };
+  spacing: { horizontal: number; vertical: number };
+  columns: number;
+  rows: number;
+};
+
+type Item = {
+  articleNumber?: string;
+  ean?: string;
+  name?: string;
+  price?: number;
+};
+
+function renderBarcodeSvg(code: string, heightMM: number): string {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  JsBarcode(svg, code, { format: 'CODE128', displayValue: false, margin: 0, height: heightMM });
+  return svg.outerHTML;
+}
+
+export function buildLabelSheetHTML(input: {
+  items: Item[];
+  layout: LayoutSettings;
+  barcodeHeightMM: number;
+  fontFamily?: string;
+}): string {
+  const { items, layout, barcodeHeightMM, fontFamily } = input;
+  const css = `@page { size: A4; margin: 0; }
+  body { margin:0; font-family:${fontFamily || 'sans-serif'}; }
+  .page { padding:${layout.pageMargin.top}mm ${layout.pageMargin.right}mm ${layout.pageMargin.bottom}mm ${layout.pageMargin.left}mm; }
+  .grid { display:grid; grid-template-columns: repeat(${layout.columns}, ${layout.labelSize.width}mm); grid-auto-rows:${layout.labelSize.height}mm; grid-column-gap:${layout.spacing.horizontal}mm; grid-row-gap:${layout.spacing.vertical}mm; }
+  .label { box-sizing:border-box; overflow:hidden; }
+  .barcode svg{ width:100%; height:${barcodeHeightMM}mm; }
+  .price{ font-weight:bold; }`;
+
+  const labelsHtml = items.map(it => {
+    const barcode = it.articleNumber ? `<div class="barcode">${renderBarcodeSvg(it.articleNumber, barcodeHeightMM)}</div>` : '';
+    const price = it.price != null ? `<div class="price">${it.price.toFixed(2)} €</div>` : '';
+    return `<div class="label"><div>${it.articleNumber || ''}</div><div>${it.name || ''}</div>${price}${barcode}</div>`;
+  }).join('');
+
+  return `<!doctype html><html><head><meta charset="utf-8"/><style>${css}</style></head><body><div class="page"><div class="grid">${labelsHtml}</div></div></body></html>`;
+}
+

--- a/src/renderer/types/global.d.ts
+++ b/src/renderer/types/global.d.ts
@@ -9,6 +9,19 @@ declare global {
         getAll: () => Promise<Record<string, unknown>>;
         reset: () => Promise<void>;
       };
+      print: {
+        labelsToPDF: (payload: {
+          jobName: string;
+          html: string;
+          pageSize?: 'A4' | 'Letter';
+          marginsMM: { top: number; right: number; bottom: number; left: number };
+          saveDialog?: boolean;
+          defaultPath?: string;
+        }) => Promise<{ ok: boolean; path?: string; dataBase64?: string; error?: string }>;
+      };
+      articles: {
+        upsertMany: (items: any[]) => Promise<any>;
+      };
     };
   }
 }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -7,6 +7,7 @@ export const IPC_CHANNELS = {
   },
   articles: {
     search: 'ipc.articles.search',
+    upsertMany: 'articles:upsertMany',
   },
   cart: {
     get: 'ipc.cart.get',


### PR DESCRIPTION
## Summary
- implement offscreen PDF label printing via IPC and preload bridge
- add barcode layout option and HTML label generator
- add CSV/XLSX/TXT import wizard with field mapping and bulk article upsert

## Testing
- `npm install` *(fails: 403 Forbidden - electron-store)*
- `npm test` *(fails: Fehlende lokale Node-Header/Lib)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68b5957742e88325821a541a668fabb2