### PR TITLE
Clamp label dimensions within A4 bounds

### DIFF
--- a/src/renderer/labels/formatSettings.ts
+++ b/src/renderer/labels/formatSettings.ts
@@ -8,6 +8,12 @@ export type LabelSettings = {
 
 const KEY = 'labelSettings.v1';
 
+export const A4W = 210;
+export const A4H = 297;
+
+export const deNumber = (v: string | number): number =>
+  typeof v === 'number' ? v : parseFloat(String(v).trim().replace(',', '.'));
+
 export function loadLabelSettings(): LabelSettings {
   const raw = localStorage.getItem(KEY);
   if (raw) return JSON.parse(raw);
@@ -26,27 +32,55 @@ export function saveLabelSettings(s: LabelSettings) {
 }
 
 export function maxLabelWidthMm(s: LabelSettings) {
-  const A4W = 210;
   return (A4W - s.page.left - s.page.right - (s.grid.cols - 1) * s.gap.col) / s.grid.cols;
 }
 
 export function maxLabelHeightMm(s: LabelSettings) {
-  const A4H = 297;
   return (A4H - s.page.top - s.page.bottom - (s.grid.rows - 1) * s.gap.row) / s.grid.rows;
 }
 
-export function normalizeForAuto(s: LabelSettings) {
-  if (s.label.autoWidth) s.label.width = Math.floor(maxLabelWidthMm(s) * 100) / 100;
-  if (s.label.autoHeight) s.label.height = Math.floor(maxLabelHeightMm(s) * 100) / 100;
+export function normalizeFromForm(s: LabelSettings) {
+  // stelle sicher, dass alles Zahlen sind – de-Format „63,5“
+  s.page.top = deNumber(s.page.top);
+  s.page.bottom = deNumber(s.page.bottom);
+  s.page.left = deNumber(s.page.left);
+  s.page.right = deNumber(s.page.right);
+  s.gap.col = deNumber(s.gap.col);
+  s.gap.row = deNumber(s.gap.row);
+  s.grid.cols = Number(s.grid.cols);
+  s.grid.rows = Number(s.grid.rows);
+  s.label.width = deNumber(s.label.width);
+  s.label.height = deNumber(s.label.height);
+}
+
+export function clampToPage(s: LabelSettings): { clampedW?: number; clampedH?: number } {
+  const maxW = maxLabelWidthMm(s);
+  const maxH = maxLabelHeightMm(s);
+  const info: { clampedW?: number; clampedH?: number } = {};
+  if (s.label.width > maxW) {
+    s.label.width = Math.floor(maxW * 100) / 100;
+    info.clampedW = s.label.width;
+  }
+  if (s.label.height > maxH) {
+    s.label.height = Math.floor(maxH * 100) / 100;
+    info.clampedH = s.label.height;
+  }
+  return info;
 }
 
 export function validateA4(s: LabelSettings): string | null {
-  const A4W = 210, A4H = 297;
-  const usedW = s.page.left + s.page.right + (s.grid.cols * s.label.width) + ((s.grid.cols - 1) * s.gap.col);
-  const usedH = s.page.top + s.page.bottom + (s.grid.rows * s.label.height) + ((s.grid.rows - 1) * s.gap.row);
-
-  if (usedW > A4W + 0.01) return `Breite überschreitet A4 (${usedW.toFixed(2)}mm > 210mm)`;
-  if (usedH > A4H + 0.01) return `Höhe überschreitet A4 (${usedH.toFixed(2)}mm > 297mm)`;
+  const totalW =
+    s.page.left +
+    s.page.right +
+    s.grid.cols * s.label.width +
+    (s.grid.cols - 1) * s.gap.col;
+  const totalH =
+    s.page.top +
+    s.page.bottom +
+    s.grid.rows * s.label.height +
+    (s.grid.rows - 1) * s.gap.row;
+  if (totalW > A4W + 1e-6) return `Breite überschreitet A4 (${totalW.toFixed(2)}mm > ${A4W}mm)`;
+  if (totalH > A4H + 1e-6) return `Höhe überschreitet A4 (${totalH.toFixed(2)}mm > ${A4H}mm)`;
   return null;
 }
 


### PR DESCRIPTION
## Summary
- parse form inputs respecting German decimal commas and normalize values
- compute maximum label size for A4 sheets, clamp oversized inputs, and validate page usage
- update dialog save handler to auto-size labels, clamp to page, and notify when values are adjusted

## Testing
- `npm test` (fails: Fehlende lokale Node-Header/Lib)
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b5b89b51b483259c9ee74ff24b8f41