### PR TITLE
Integrate local cart with label preview

### DIFF
--- a/src/renderer/components/ArticleSearch.tsx
+++ b/src/renderer/components/ArticleSearch.tsx
@@ -5,12 +5,16 @@ import ImportWizard from './ImportWizard';
 import { z } from 'zod';
 import { fromArticleToEan13, isValidEan13, onlyDigits } from '../lib/labels';
 
+interface Props {
+  onCartChange?: (items: any[]) => void;
+}
+
 const currency = new Intl.NumberFormat('de-AT', {
   style: 'currency',
   currency: 'EUR',
 });
 
-const ArticleSearch: React.FC = () => {
+const ArticleSearch: React.FC<Props> = ({ onCartChange }) => {
   const [query, setQuery] = useState('');
   const [page, setPage] = useState(1);
   const [pageSize] = useState(50);
@@ -299,6 +303,10 @@ const ArticleSearch: React.FC = () => {
     };
 
     const totalSelected = selectedIds.size;
+
+    useEffect(() => {
+      if (onCartChange) onCartChange(cart);
+    }, [cart, onCartChange]);
 
   return (
     <>

--- a/src/renderer/components/PreviewPane.tsx
+++ b/src/renderer/components/PreviewPane.tsx
@@ -47,38 +47,26 @@ function cssVarsStyleTag(s: LabelSettings) {
   }</style>`;
 }
 
-type Props = { opts: LabelOptions };
+type Props = { opts: LabelOptions; cart: any[] };
 
-const PreviewPane: React.FC<Props> = ({ opts }) => {
+const PreviewPane: React.FC<Props> = ({ opts, cart }) => {
   const [openLayout, setOpenLayout] = useState(false);
   const [settings, setSettings] = useState<LabelSettings>(() => loadLabelSettings());
 
-  useEffect(() => { applyCssVars(settings); }, [settings]);
-
-  const [cart, setCart] = useState<{ articleId: string; qty: number }[]>([]);
   useEffect(() => {
-    (async () => {
-      const c = (await window.bridge?.cart?.get?.()) || [];
-      setCart(c.map((x: any) => ({ articleId: x.articleId, qty: x.qty })));
-    })();
-  }, []);
-
-  async function getArticle(articleId: string) {
-    const a = await window.bridge?.articles?.getById?.(articleId);
-    return a || { articleNumber: articleId, name: articleId, price: undefined };
-  }
+    applyCssVars(settings);
+  }, [settings]);
 
   async function buildLabelsHtml(): Promise<string> {
     let labels = '';
     for (const item of cart) {
-      const art = await getArticle(item.articleId);
       for (let i = 0; i < item.qty; i++) {
         labels += `
           <div class="label">
-            ${opts.showArticleNumber && art.articleNumber ? `<div class="label__sku">${art.articleNumber}</div>` : ''}
-            ${opts.showShortText && art.name ? `<div class="label__title">${art.name}</div>` : ''}
-            ${opts.showListPrice && art.price != null ? `<div class="label__price">${Number(art.price).toFixed(2)} €</div>` : ''}
-            ${opts.showEan && art.articleNumber ? `
+            ${opts.showArticleNumber && item.articleNumber ? `<div class="label__sku">${item.articleNumber}</div>` : ''}
+            ${opts.showShortText && item.name ? `<div class="label__title">${item.name}</div>` : ''}
+            ${opts.showListPrice && item.price != null ? `<div class="label__price">${Number(item.price).toFixed(2)} €</div>` : ''}
+            ${opts.showEan && item.ean ? `
               <div class="label__barcode">
                 <svg width="180" height="40"><rect width="180" height="40" fill="#000"/></svg>
               </div>

--- a/src/renderer/components/Shell.tsx
+++ b/src/renderer/components/Shell.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import ImportPane from './ImportPane';
 import ArticleSearch from './ArticleSearch';
-import CartPane from './CartPane';
 import LabelOptionsPane, { LabelOptions } from './LabelOptionsPane';
 import PreviewPane from './PreviewPane';
 
@@ -13,14 +12,7 @@ const Shell: React.FC = () => {
     showListPrice: true,
     showImage: false,
   });
-  const [cartCount, setCartCount] = useState(0);
-  const refreshCart = async () => {
-    const c = (await window.bridge?.cart?.get?.()) || [];
-    setCartCount(c.length);
-  };
-  useEffect(() => {
-    refreshCart();
-  }, []);
+  const [cart, setCart] = useState<any[]>([]);
   return (
     <div>
       {!window.bridge && (
@@ -30,11 +22,10 @@ const Shell: React.FC = () => {
       )}
       <h1>Etiketten</h1>
       <ImportPane />
-      <ArticleSearch />
+      <ArticleSearch onCartChange={setCart} />
       <LabelOptionsPane opts={opts} onChange={setOpts} />
-      <CartPane onChange={refreshCart} />
-      <div>Warenkorb: {cartCount} Artikel</div>
-      <PreviewPane opts={opts} />
+      <div>Warenkorb: {cart.length} Artikel</div>
+      <PreviewPane opts={opts} cart={cart} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Track cart items in `Shell` via `ArticleSearch` callback
- Rework preview to render labels from the local cart
- Notify parent on cart updates

## Testing
- `npm test` *(fails: missing local Node headers)*

------
https://chatgpt.com/codex/tasks/task_e_68b808eb8e9c83258de6f55aa90b1251