### PR TITLE
feat: restore label layout button

### DIFF
--- a/src/renderer/components/PreviewPane.tsx
+++ b/src/renderer/components/PreviewPane.tsx
@@ -51,7 +51,9 @@ const PreviewPane: React.FC<Props> = ({ opts, cart }) => {
   return (
     <div className="labels-page">
       <div className="toolbar">
-        <button onClick={() => setOpenLayout(true)}>Etiketten formatieren</button>
+        <button type="button" onClick={() => setOpenLayout(true)}>
+          Etiketten formatieren
+        </button>
         <button className="primary" onClick={handlePrint} type="button">
           PDF-Etiketten erzeugen
         </button>

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -135,7 +135,7 @@ fieldset > label {
 
 .labels-page .toolbar {
   display: flex;
-  justify-content: flex-end;
+  justify-content: flex-start;
   margin: 8px 0 14px 0;
   gap: 8px;
 }


### PR DESCRIPTION
## Summary
- ensure label layout configuration button is present and non-submitting
- align label toolbar to display both configuration and PDF generation buttons

## Testing
- `npm test` *(fails: Missing local Node headers)*

------
https://chatgpt.com/codex/tasks/task_e_68b8116bd6f0832586423ed5380b8ea9