### PR TITLE
feat: harden preload and add build-time CSP

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "etiketten",
   "version": "0.1.0",
   "private": true,
-  "main": "src/main/main.ts",
+  "main": "build/main.js",
   "scripts": {
     "dev": "npm run build:preload && concurrently -k \"npm:dev:renderer\" \"npm:dev:main\"",
     "dev:renderer": "vite --config vite.config.mts",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -18,14 +18,14 @@ function createMainWindow() {
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: true,
-      preload: path.join(__dirname, '../preload.js'),
+      preload: path.join(app.getAppPath(), 'build', 'preload.js'),
     },
   });
 
   mainWindow.webContents.on('will-navigate', (event, url) => {
     const isDev = !app.isPackaged;
     const allowed =
-      (isDev && url.startsWith('http://localhost')) ||
+      (isDev && url.startsWith('http://localhost:5173')) ||
       (!isDev && url.startsWith('file://'));
     if (!allowed) event.preventDefault();
   });
@@ -34,7 +34,7 @@ function createMainWindow() {
 
   if (app.isPackaged) {
     mainWindow.removeMenu();
-    void mainWindow.loadFile(path.join(__dirname, '../../dist/index.html'));
+    void mainWindow.loadFile(path.join(app.getAppPath(), 'dist', 'index.html'));
   } else {
     void mainWindow.loadURL('http://localhost:5173');
     mainWindow.webContents.openDevTools();

--- a/tsconfig.main.json
+++ b/tsconfig.main.json
@@ -2,6 +2,14 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "skipLibCheck": true,
-    "types": ["node"]
-  }
+    "types": ["node"],
+    "outDir": "build",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/main/**/*.ts",
+    "src/shared/**/*.ts",
+    "src/types/**/*.d.ts"
+  ],
+  "exclude": ["src/preload.ts", "src/renderer"]
 }

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,13 +1,14 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
+import csp from './vite.csp';
 
 export default defineConfig({
   root: path.resolve(__dirname, 'src/renderer'),
   base: './',
-  plugins: [react()],
+  plugins: [react(), csp()],
   build: {
-    outDir: path.resolve(__dirname, 'dist/renderer'),
+    outDir: path.resolve(__dirname, 'dist'),
     emptyOutDir: true,
   },
 });

--- a/vite.csp.ts
+++ b/vite.csp.ts
@@ -1,0 +1,16 @@
+import type { Plugin } from 'vite';
+
+export default function cspPlugin(): Plugin {
+  const csp = "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self'; font-src 'self' data:; object-src 'none'; base-uri 'self'; frame-ancestors 'none';";
+
+  return {
+    name: 'vite-plugin-csp',
+    apply: 'build',
+    transformIndexHtml(html) {
+      return html.replace(
+        /<head>/i,
+        `<head>\n    <meta http-equiv="Content-Security-Policy" content="${csp}">`,
+      );
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- resolve preload from app root for reliable dev/prod usage
- add production-only CSP injection via custom Vite plugin
- refine build scripts for main, preload and renderer outputs

## Testing
- `npm test` *(fails: fehlende lokale Node-Header/Lib)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b81bb29cc8832588a2a22fc13e256f