### PR TITLE
Remove Windows codesigning configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,9 +97,7 @@
     "win": {
       "icon": "build/icon.ico",
       "artifactName": "ETU-Etiketten-${version}-Setup.${ext}",
-      "target": "nsis",
-      "certificateFile": "${WINDOWS_PFX_FILE}",
-      "certificatePassword": "${WINDOWS_PFX_PASSWORD}"
+      "target": "nsis"
     },
     "nsis": {
       "oneClick": false,


### PR DESCRIPTION
## Summary
- remove certificateFile and certificatePassword from electron-builder Windows config

## Testing
- `npm test` *(fails: Fehlende lokale Node-Header/Lib)*

------
https://chatgpt.com/codex/tasks/task_e_68b83b275e108325b674355e075b6eb3