### PR TITLE
fix: correct electron entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Etikettenerstellungs-Software",
   "author": "ETU GmbH",
   "private": true,
-  "main": "build/main.js",
+  "main": "build/main/main.js",
   "scripts": {
     "dev": "npm run build:preload && concurrently -k \"npm:dev:renderer\" \"npm:dev:main\"",
     "dev:renderer": "vite --config vite.config.mts",


### PR DESCRIPTION
## Summary
- update electron entry point to `build/main/main.js`

## Testing
- `npm test` *(fails: Fehlende lokale Node-Header/Lib)*

------
https://chatgpt.com/codex/tasks/task_e_68b83f8693f08325b1e2f16fa1cda385