### PR TITLE
feat(ui): show Import (CSV/XLSX/TXT) button always; disable with tooltip when cart is empty to prevent layout shift

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,7 +1,7 @@
 export default {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  testMatch: ['**/tests/**/*.spec.ts'],
+  testMatch: ['**/tests/**/*.spec.ts', '**/tests/**/*.spec.tsx'],
   transform: {
     '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.jest.json' }]
   }

--- a/src/renderer/components/ArticleSearch.tsx
+++ b/src/renderer/components/ArticleSearch.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Button, Input, Checkbox } from '@fluentui/react-components';
 import CategoryManager from './CategoryManager';
 import ImportWizard from './ImportWizard';
+import CartActions from './CartActions';
 import { z } from 'zod';
 import { fromArticleToEan13, isValidEan13, onlyDigits } from '../lib/labels';
 
@@ -594,23 +595,11 @@ const ArticleSearch: React.FC<Props> = ({ onCartChange }) => {
                 </li>
               ))}
             </ul>
-            {cart.length > 0 && (
-              <div
-                style={{
-                  marginTop: '8px',
-                  display: 'flex',
-                  flexDirection: 'column',
-                  gap: '8px',
-                }}
-              >
-                <div style={{ display: 'flex', gap: '8px' }}>
-                  <Button onClick={() => setCart([])}>Warenkorb leeren</Button>
-                  <Button onClick={() => setImportOpen(true)}>
-                    Importieren (CSV/XLSX/TXT)
-                  </Button>
-                </div>
-              </div>
-            )}
+            <CartActions
+              hasItems={cart.length > 0}
+              onClear={() => setCart([])}
+              onImport={() => setImportOpen(true)}
+            />
           </div>
         </div>
       </div>

--- a/src/renderer/components/CartActions.tsx
+++ b/src/renderer/components/CartActions.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Button, Tooltip } from '@fluentui/react-components';
+
+type Props = {
+  hasItems: boolean;
+  onClear: () => void;
+  onImport: () => void;
+};
+
+const CartActions: React.FC<Props> = ({ hasItems, onClear, onImport }) => {
+  const disabled = !hasItems;
+  return (
+    <div
+      style={{
+        marginTop: '8px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '8px',
+      }}
+    >
+      <div style={{ display: 'flex', gap: '8px' }}>
+        <Button onClick={onClear} disabled={disabled}>
+          Warenkorb leeren
+        </Button>
+        <Tooltip
+          content="Import erfordert mindestens 1 Artikel im Warenkorb."
+          relationship="label"
+          disabled={!disabled}
+        >
+          <span style={{ display: 'inline-flex' }}>
+            <Button
+              onClick={onImport}
+              disabled={disabled}
+              aria-disabled={disabled}
+              aria-label="Importieren (CSV/XLSX/TXT)"
+              title={disabled ? 'Import erfordert mindestens 1 Artikel im Warenkorb.' : undefined}
+            >
+              Importieren (CSV/XLSX/TXT)
+            </Button>
+          </span>
+        </Tooltip>
+      </div>
+    </div>
+  );
+};
+
+export default CartActions;

--- a/tests/cart-actions.spec.tsx
+++ b/tests/cart-actions.spec.tsx
@@ -1,0 +1,28 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import CartActions from '../src/renderer/components/CartActions';
+
+describe('CartActions Import Button', () => {
+  it('renders disabled import button when cart empty', () => {
+    const div = document.createElement('div');
+    ReactDOM.render(
+      <CartActions hasItems={false} onClear={() => {}} onImport={() => {}} />,
+      div,
+    );
+    const buttons = div.querySelectorAll('button');
+    expect(buttons.length).toBe(2);
+    const importBtn = buttons[1] as HTMLButtonElement;
+    expect(importBtn.disabled).toBe(true);
+  });
+
+  it('renders enabled import button when cart has items', () => {
+    const div = document.createElement('div');
+    ReactDOM.render(
+      <CartActions hasItems={true} onClear={() => {}} onImport={() => {}} />,
+      div,
+    );
+    const importBtn = div.querySelectorAll('button')[1] as HTMLButtonElement;
+    expect(importBtn.disabled).toBe(false);
+  });
+});

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "moduleResolution": "node",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "jsx": "react-jsx"
   },
   "include": ["tests/**/*.ts", "tests/**/*.tsx", "types/**/*.d.ts"]
 }


### PR DESCRIPTION
## Summary
- render new CartActions component so Import button stays visible
- disable Import action without cart items and show tooltip
- add Jest/TS config and component test for Import button state

## Testing
- `npx jest tests/cart-actions.spec.tsx` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm test` *(fails: Fehlende lokale Node-Header/Lib: - C:\/node-headers/v20.19.4/include/node/node_api.h, ...)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b8851c7be08325bc5890fbdbd0ac7d