### PR TITLE
fix(ui): enable Import (CSV/XLSX/TXT) button regardless of cart state; keep 'clear cart' disabled when empty

### DIFF
--- a/src/renderer/components/CartActions.tsx
+++ b/src/renderer/components/CartActions.tsx
@@ -8,7 +8,7 @@ type Props = {
 };
 
 const CartActions: React.FC<Props> = ({ hasItems, onClear, onImport }) => {
-  const disabled = !hasItems;
+  const clearDisabled = !hasItems;
   return (
     <div
       style={{
@@ -19,21 +19,15 @@ const CartActions: React.FC<Props> = ({ hasItems, onClear, onImport }) => {
       }}
     >
       <div style={{ display: 'flex', gap: '8px' }}>
-        <Button onClick={onClear} disabled={disabled}>
+        <Button onClick={onClear} disabled={clearDisabled}>
           Warenkorb leeren
         </Button>
-        <Tooltip
-          content="Import erfordert mindestens 1 Artikel im Warenkorb."
-          relationship="label"
-          disabled={!disabled}
-        >
+        <Tooltip content="Dateien importieren (CSV/XLSX/TXT)" relationship="label">
           <span style={{ display: 'inline-flex' }}>
             <Button
               onClick={onImport}
-              disabled={disabled}
-              aria-disabled={disabled}
-              aria-label="Importieren (CSV/XLSX/TXT)"
-              title={disabled ? 'Import erfordert mindestens 1 Artikel im Warenkorb.' : undefined}
+              aria-label="Dateien importieren (CSV/XLSX/TXT)"
+              title="Dateien importieren (CSV/XLSX/TXT)"
             >
               Importieren (CSV/XLSX/TXT)
             </Button>

--- a/tests/cart-actions.spec.tsx
+++ b/tests/cart-actions.spec.tsx
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom';
 import CartActions from '../src/renderer/components/CartActions';
 
 describe('CartActions Import Button', () => {
-  it('renders disabled import button when cart empty', () => {
+  it('enables import and disables clear button when cart empty', () => {
     const div = document.createElement('div');
     ReactDOM.render(
       <CartActions hasItems={false} onClear={() => {}} onImport={() => {}} />,
@@ -12,17 +12,23 @@ describe('CartActions Import Button', () => {
     );
     const buttons = div.querySelectorAll('button');
     expect(buttons.length).toBe(2);
+    const clearBtn = buttons[0] as HTMLButtonElement;
     const importBtn = buttons[1] as HTMLButtonElement;
-    expect(importBtn.disabled).toBe(true);
+    expect(clearBtn.disabled).toBe(true);
+    expect(importBtn.disabled).toBe(false);
   });
 
-  it('renders enabled import button when cart has items', () => {
+  it('enables both buttons when cart has items', () => {
     const div = document.createElement('div');
     ReactDOM.render(
       <CartActions hasItems={true} onClear={() => {}} onImport={() => {}} />,
       div,
     );
-    const importBtn = div.querySelectorAll('button')[1] as HTMLButtonElement;
+    const buttons = div.querySelectorAll('button');
+    expect(buttons.length).toBe(2);
+    const clearBtn = buttons[0] as HTMLButtonElement;
+    const importBtn = buttons[1] as HTMLButtonElement;
+    expect(clearBtn.disabled).toBe(false);
     expect(importBtn.disabled).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- always enable Import (CSV/XLSX/TXT) button
- keep Clear cart button disabled when cart is empty
- adjust CartActions tests accordingly

## Testing
- `npm run typecheck`
- `npm test` *(fails: Missing local Node headers for better-sqlite3 rebuild)*


------
https://chatgpt.com/codex/tasks/task_e_68b887bd34588325a7f618cd2e71efef