### PR TITLE
fix(import): make Import starten robust

### DIFF
--- a/src/main/db.ts
+++ b/src/main/db.ts
@@ -36,6 +36,8 @@ const stmtUpdate = db.prepare(
 );
 
 export function upsertArticles(batch: any[]) {
+  if (!batch.length) return { inserted: 0, updated: 0 };
+  console.info(`upsertArticles count=${batch.length}`); // debug info
   const tx = db.transaction((rows: any[]) => {
     let inserted = 0;
     let updated = 0;
@@ -63,7 +65,12 @@ export function upsertArticles(batch: any[]) {
     }
     return { inserted, updated };
   });
-  return tx(batch);
+  try {
+    return tx(batch);
+  } catch (err) {
+    console.error('upsertArticles failed', err);
+    throw err;
+  }
 }
 
 export function getDbInfo() {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -68,7 +68,11 @@ const api = {
     }) => ipcRenderer.invoke('print:labelsToPDF', payload),
   },
   articles: {
-    upsertMany: (items: any[]) => ipcRenderer.invoke('articles:upsertMany', items),
+    upsertMany: (items: any[]) =>
+      ipcRenderer.invoke('articles:upsertMany', items) as Promise<
+        { ok: true; inserted: number; updated: number } |
+        { ok: false; code?: string; message: string }
+      >,
   },
 };
 

--- a/src/renderer/components/ImportWizard.tsx
+++ b/src/renderer/components/ImportWizard.tsx
@@ -29,13 +29,22 @@ export const ImportWizard: React.FC<Props> = ({ open, onClose }) => {
   };
 
   const startImport = async () => {
+    setError(null);
     const items = applyMapping({ rows, headers, mapping });
     if (!items.length) {
       setError('Keine gültigen Daten gefunden');
       return;
     }
-    await window.api.articles.upsertMany(items as any);
-    onClose();
+    try {
+      const res = await window.api.articles.upsertMany(items as any);
+      if (res?.ok) {
+        onClose();
+      } else {
+        setError(res?.message || 'Import fehlgeschlagen');
+      }
+    } catch (err: any) {
+      setError(String(err.message || err));
+    }
   };
 
   if (!open) return null;

--- a/src/renderer/lib/import/applyMapping.ts
+++ b/src/renderer/lib/import/applyMapping.ts
@@ -17,14 +17,20 @@ export function applyMapping({ rows, headers, mapping }: { rows: any[]; headers:
       const get = (field: string) => r[idx[mapping[field]] ?? -1];
       const articleNumber = String(get('artikelnummer') ?? '').trim();
       if (!articleNumber) return null;
+
       const eanRaw = String(get('ean') ?? '').trim();
-      const ean = isValidEan(eanRaw) ? eanRaw : undefined;
+      const ean = isValidEan(eanRaw) ? eanRaw : null;
+
+      const name = String(get('kurztext') ?? '').trim();
+      const price = normalizePrice(get('preis')) ?? 0;
+      const unit = String(get('einheit') ?? '').trim();
+
       return {
         articleNumber,
         ean,
-        name: String(get('kurztext') ?? '').trim(),
-        price: normalizePrice(get('preis')), 
-        unit: String(get('einheit') ?? '').trim() || null,
+        name: name || '(ohne Bezeichnung)',
+        price,
+        unit: unit || null,
       };
     })
     .filter(Boolean);


### PR DESCRIPTION
## Summary
- normalize and map import rows with defaults
- surface import errors in dialog and ipc
- validate upsertMany payload and wrap db updates in transactional logging

## Testing
- `npm run typecheck`
- `npm test` *(fails: Fehlende lokale Node-Header/Lib)*

------
https://chatgpt.com/codex/tasks/task_e_68b88a1f71c883258c50b20c3d4e8783