### PR TITLE
fix(import/db): resolve SQLITE_ERROR in transactional upsert

### DIFF
--- a/src/main/db.migrations.ts
+++ b/src/main/db.migrations.ts
@@ -43,9 +43,9 @@ export function ensureSchema(db: DatabaseType) {
       SELECT id, CAST(articleNumber AS TEXT), ean, name, price, unit, productGroup, created_at, updated_at FROM _articles_old;
     `);
     db.exec(`DROP TABLE _articles_old;`);
-    db.exec(`CREATE INDEX IF NOT EXISTS idx_articles_articlenumber ON articles(articleNumber);`);
+    db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_articles_articlenumber ON articles(articleNumber);`);
     db.exec(`CREATE INDEX IF NOT EXISTS idx_articles_name ON articles(name);`);
-    db.exec(`CREATE INDEX IF NOT EXISTS idx_articles_ean ON articles(ean);`);
+    db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_articles_ean ON articles(ean);`);
   }
   if (!names.includes('ean')) {
     db.exec(`ALTER TABLE articles ADD COLUMN ean TEXT;`);
@@ -74,9 +74,9 @@ export function ensureSchema(db: DatabaseType) {
     db.exec(`ALTER TABLE articles ADD COLUMN updated_at DATETIME DEFAULT CURRENT_TIMESTAMP;`);
   }
 
-  db.exec(`CREATE INDEX IF NOT EXISTS idx_articles_articlenumber ON articles(articleNumber);`);
+  db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_articles_articlenumber ON articles(articleNumber);`);
   db.exec(`CREATE INDEX IF NOT EXISTS idx_articles_name ON articles(name);`);
-  db.exec(`CREATE INDEX IF NOT EXISTS idx_articles_ean ON articles(ean);`);
+  db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_articles_ean ON articles(ean);`);
   db.exec(`CREATE INDEX IF NOT EXISTS idx_articles_category_id ON articles(category_id);`);
 
   db.exec(`

--- a/src/main/db.ts
+++ b/src/main/db.ts
@@ -38,6 +38,16 @@ const stmtUpdate = db.prepare(
    WHERE articleNumber=@articleNumber`,
 );
 
+const UPSERT_COLS = [
+  'articleNumber',
+  'ean',
+  'name',
+  'price',
+  'unit',
+  'productGroup',
+  'category_id',
+];
+
 function parsePrice(v: unknown): number {
   if (v == null) return 0;
   const n = Number(String(v).replace(',', '.'));
@@ -73,6 +83,9 @@ export function upsertArticles(batch: any[]) {
             ? Number(raw.category_id)
             : null,
       };
+      if (i === 0) {
+        console.debug('upsertArticles row0 mapped', { columns: UPSERT_COLS, values: item });
+      }
       try {
         const ins = stmtInsert.run(item);
         if (ins.changes === 0) {
@@ -90,6 +103,13 @@ export function upsertArticles(batch: any[]) {
       } catch (e: any) {
         e.row = i;
         e.articleNumber = item.articleNumber;
+        if (i === 0) {
+          console.error('upsertArticles row0 failed', {
+            columns: UPSERT_COLS,
+            values: item,
+            message: e.message,
+          });
+        }
         throw e;
       }
     }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -70,8 +70,8 @@ const api = {
   articles: {
     upsertMany: (items: any[]) =>
       ipcRenderer.invoke('articles:upsertMany', items) as Promise<
-        { ok: true; inserted: number; updated: number } |
-        { ok: false; code?: string; message: string }
+        | { ok: true; inserted: number; updated: number }
+        | { ok: false; code?: string; message: string; details?: any }
       >,
   },
 };

--- a/src/renderer/components/ImportWizard.tsx
+++ b/src/renderer/components/ImportWizard.tsx
@@ -30,7 +30,14 @@ export const ImportWizard: React.FC<Props> = ({ open, onClose }) => {
 
   const startImport = async () => {
     setError(null);
-    const items = applyMapping({ rows, headers, mapping });
+    const { items, errors } = applyMapping({ rows, headers, mapping });
+    console.info(`importing ${items.length} rows`);
+    if (items[0]) console.info('sample row', { index: 0, articleNumber: items[0].articleNumber });
+    if (errors.length) {
+      const e = errors[0];
+      setError(`Fehler in Zeile ${e.row + 1}: Feld ${e.field}`);
+      return;
+    }
     if (!items.length) {
       setError('Keine gültigen Daten gefunden');
       return;
@@ -40,7 +47,9 @@ export const ImportWizard: React.FC<Props> = ({ open, onClose }) => {
       if (res?.ok) {
         onClose();
       } else {
-        setError(res?.message || 'Import fehlgeschlagen');
+        const rowInfo = (res as any)?.details;
+        const prefix = rowInfo ? `Zeile ${Number(rowInfo.row) + 1} (${rowInfo.articleNumber}): ` : '';
+        setError(prefix + (res?.message || 'Import fehlgeschlagen'));
       }
     } catch (err: any) {
       setError(String(err.message || err));

--- a/src/renderer/lib/import/applyMapping.ts
+++ b/src/renderer/lib/import/applyMapping.ts
@@ -9,30 +9,47 @@ const normalizePrice = (v: any): number | null => {
 
 const isValidEan = (ean: string): boolean => /^(\d{8}|\d{12,13})$/.test(ean);
 
-export function applyMapping({ rows, headers, mapping }: { rows: any[]; headers: string[]; mapping: Mapping }) {
+export function applyMapping({
+  rows,
+  headers,
+  mapping,
+}: {
+  rows: any[];
+  headers: string[];
+  mapping: Mapping;
+}) {
   const idx: Record<string, number> = {};
   headers.forEach((h, i) => (idx[h] = i));
-  return rows
-    .map((r) => {
-      const get = (field: string) => r[idx[mapping[field]] ?? -1];
-      const articleNumber = String(get('artikelnummer') ?? '').trim();
-      if (!articleNumber) return null;
+  const items: any[] = [];
+  const errors: { row: number; field: string }[] = [];
+  const seenEan = new Set<string>();
+  rows.forEach((r, rowIdx) => {
+    const get = (field: string) => r[idx[mapping[field]] ?? -1];
+    const articleNumber = String(get('artikelnummer') ?? '').trim();
+    if (!articleNumber) {
+      errors.push({ row: rowIdx, field: 'artikelnummer' });
+      return;
+    }
 
-      const eanRaw = String(get('ean') ?? '').trim();
-      const ean = isValidEan(eanRaw) ? eanRaw : null;
+    const eanRaw = String(get('ean') ?? '').trim();
+    const ean = eanRaw && isValidEan(eanRaw) ? eanRaw : null;
+    if (eanRaw && !ean) errors.push({ row: rowIdx, field: 'ean' });
+    if (ean && seenEan.has(ean)) errors.push({ row: rowIdx, field: 'ean' });
+    if (ean) seenEan.add(ean);
 
-      const name = String(get('kurztext') ?? '').trim();
-      const price = normalizePrice(get('preis')) ?? 0;
-      const unit = String(get('einheit') ?? '').trim();
+    const name = String(get('kurztext') ?? '').trim();
+    const price = normalizePrice(get('preis'));
+    if (price == null) errors.push({ row: rowIdx, field: 'preis' });
+    const unit = String(get('einheit') ?? '').trim();
 
-      return {
-        articleNumber,
-        ean,
-        name: name || '(ohne Bezeichnung)',
-        price,
-        unit: unit || null,
-      };
-    })
-    .filter(Boolean);
+    items.push({
+      articleNumber,
+      ean,
+      name: name || '(ohne Bezeichnung)',
+      price: price ?? 0,
+      unit: unit || null,
+    });
+  });
+  return { items, errors };
 }
 

--- a/tests/import.mapping.spec.ts
+++ b/tests/import.mapping.spec.ts
@@ -1,0 +1,42 @@
+import { applyMapping } from '../src/renderer/lib/import/applyMapping';
+
+const headers = ['Artikelnr', 'Kurztext', 'Listenpreis', 'Mengeneinheit', 'EAN'];
+const mapping = {
+  artikelnummer: 'Artikelnr',
+  kurztext: 'Kurztext',
+  preis: 'Listenpreis',
+  einheit: 'Mengeneinheit',
+  ean: 'EAN',
+};
+
+describe('applyMapping', () => {
+  test('maps and normalizes fields', () => {
+    const rows = [[' degu123 ', 'Test', '12,34', 'kg', '12345678']];
+    const { items, errors } = applyMapping({ rows, headers, mapping });
+    expect(errors).toHaveLength(0);
+    expect(items[0]).toEqual({
+      articleNumber: 'degu123',
+      ean: '12345678',
+      name: 'Test',
+      price: 12.34,
+      unit: 'kg',
+    });
+  });
+
+  test('invalid rows yield errors', () => {
+    const rows = [['', '', '', '', '']];
+    const { items, errors } = applyMapping({ rows, headers, mapping });
+    expect(items).toHaveLength(0);
+    expect(errors[0].field).toBe('artikelnummer');
+  });
+
+  test('duplicate ean flagged', () => {
+    const rows = [
+      ['a1', 'n1', '1', 'St', '12345678'],
+      ['a2', 'n2', '2', 'St', '12345678'],
+    ];
+    const { errors } = applyMapping({ rows, headers, mapping });
+    expect(errors.some((e) => e.field === 'ean')).toBe(true);
+  });
+});
+

--- a/tests/upsertArticles.spec.ts
+++ b/tests/upsertArticles.spec.ts
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+jest.mock('electron', () => ({
+  app: {
+    getPath: () => fs.mkdtempSync(path.join(os.tmpdir(), 'db-')),
+  },
+}));
+
+import { clearArticles, upsertArticles } from '../src/main/db';
+
+describe('upsertArticles', () => {
+  test('imports and updates 53 rows', () => {
+    clearArticles();
+    const batch = Array.from({ length: 53 }, (_, i) => ({
+      articleNumber: i === 0 ? 'degu123' : `art${i}`,
+      name: `Artikel ${i}`,
+      price: i,
+      unit: 'St',
+      productGroup: null,
+      category_id: null,
+      ean: null,
+    }));
+    const res1 = upsertArticles(batch);
+    expect(res1.inserted + res1.updated).toBe(53);
+    const res2 = upsertArticles(batch);
+    expect(res2.inserted).toBe(0);
+    expect(res2.updated).toBe(53);
+  });
+});
+


### PR DESCRIPTION
## Summary
- ensure article table uses UNIQUE indexes for proper ON CONFLICT handling
- log and surface failing rows in transactional upsert
- harden import mapping/validation and show row level errors in UI

## Testing
- `npm run typecheck`
- `npm test` *(fails: Fehlende lokale Node-Header/Lib)*

------
https://chatgpt.com/codex/tasks/task_e_68b88ec4cb64832583b0bf183bfa34e8