### PR TITLE
fix(ipc): register missing main handlers for db:info and categories:list; align channel names; typed preload bridge; unified response schema; remove ‘No handler registered’ errors

### DIFF
--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -14,6 +14,7 @@ import {
   renameCategory,
   deleteCategory,
 } from '../db';
+import { IPC_CHANNELS, ok, err } from '../../shared/ipc';
 import { registerCartHandlers } from './cart';
 import { registerLabelsHandlers } from './labels';
 import { registerShellHandlers } from './shell';
@@ -40,16 +41,34 @@ export function registerIpcHandlers() {
   ipcMain.handle('custom:update', (_e, { id, patch }) => updateCustomArticle(id, patch));
   ipcMain.handle('custom:delete', (_e, id) => deleteCustomArticle(id));
 
-  ipcMain.handle('categories:list', () => listCategories());
-  ipcMain.handle('categories:create', (_e, name) => createCategory(name));
-  ipcMain.handle('categories:update', (_e, { id, name }) => renameCategory(id, name));
-  ipcMain.handle('categories:delete', (_e, payload) =>
+  ipcMain.handle(IPC_CHANNELS.categories.list, () => {
+    try {
+      return ok(listCategories());
+    } catch (e: any) {
+      return err('DB_ERROR', e.message);
+    }
+  });
+  ipcMain.handle(IPC_CHANNELS.categories.create, (_e, name) => createCategory(name));
+  ipcMain.handle(IPC_CHANNELS.categories.update, (_e, { id, name }) => renameCategory(id, name));
+  ipcMain.handle(IPC_CHANNELS.categories.delete, (_e, payload) =>
     deleteCategory(payload.id, payload.mode, payload.reassignToId),
   );
 
-  ipcMain.handle('db:info', () => getDbInfo());
+  ipcMain.handle(IPC_CHANNELS.db.info, () => {
+    try {
+      return ok(getDbInfo());
+    } catch (e: any) {
+      return err('DB_ERROR', e.message);
+    }
+  });
 
-  ipcMain.handle('db:clear', () => clearArticles());
+  ipcMain.handle(IPC_CHANNELS.db.clear, () => {
+    try {
+      return ok(clearArticles());
+    } catch (e: any) {
+      return err('DB_ERROR', e.message);
+    }
+  });
 
   ipcMain.handle('dialog:pick-datanorm', async () => {
     const { canceled, filePaths } = await dialog.showOpenDialog({

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -50,10 +50,12 @@ async function loadIpcModules() {
   for (const m of modules) {
     try {
       const mod = await import(m);
-      if (typeof mod.registerIpcHandlers === 'function') mod.registerIpcHandlers();
-      if (typeof mod.registerSettingsHandlers === 'function') mod.registerSettingsHandlers();
-    } catch {
-      /* ignore */
+      const resolved = (mod as any).default ?? mod;
+      if (typeof resolved.registerIpcHandlers === 'function') resolved.registerIpcHandlers();
+      if (typeof resolved.registerSettingsHandlers === 'function') resolved.registerSettingsHandlers();
+      if (typeof resolved.registerPrintHandlers === 'function') resolved.registerPrintHandlers();
+    } catch (err) {
+      console.error('Failed to load IPC module', m, err);
     }
   }
 }

--- a/src/renderer/components/ArticleSearch.tsx
+++ b/src/renderer/components/ArticleSearch.tsx
@@ -55,13 +55,22 @@ const ArticleSearch: React.FC<Props> = ({ onCartChange }) => {
     }, [artnr, autoEan, eanDirty]);
 
   const loadInfo = async () => {
-    const info = await window.bridge?.dbInfo?.();
-    if (info) setDbInfoText(`DB enthält ${info.rowCount} Artikel`);
+    const res = await window.bridge?.dbInfo?.();
+    if (res?.ok) {
+      setDbInfoText(`DB enthält ${res.data.rowCount} Artikel`);
+    } else if (res?.error) {
+      console.error('dbInfo failed', res.error);
+    }
   };
 
   const loadCategories = async () => {
-    const list = await window.bridge?.categories?.list();
-    setCategories(list || []);
+    const res = await window.bridge?.categories?.list();
+    if (res?.ok) {
+      setCategories(res.data);
+    } else if (res?.error) {
+      console.error('categories.list failed', res.error);
+      setCategories([]);
+    }
   };
 
   const refreshList = async (

--- a/src/renderer/components/CategoryManager.tsx
+++ b/src/renderer/components/CategoryManager.tsx
@@ -14,8 +14,13 @@ const CategoryManager: React.FC<{ open: boolean; onClose: () => void }> = ({ ope
   const [newName, setNewName] = useState('');
 
   const load = async () => {
-    const list = await window.bridge?.categories?.list();
-    setCategories(list || []);
+    const res = await window.bridge?.categories?.list();
+    if (res?.ok) {
+      setCategories(res.data);
+    } else if (res?.error) {
+      console.error('categories.list failed', res.error);
+      setCategories([]);
+    }
   };
 
   useEffect(() => {

--- a/src/renderer/components/ImportPane.tsx
+++ b/src/renderer/components/ImportPane.tsx
@@ -19,13 +19,22 @@ const ImportPane: React.FC = () => {
   const [catManagerOpen, setCatManagerOpen] = useState(false);
 
   const loadInfo = async () => {
-    const info = await window.bridge?.dbInfo?.();
-    if (info) setDbInfoText(`DB enthält ${info.rowCount} Artikel`);
+    const res = await window.bridge?.dbInfo?.();
+    if (res?.ok) {
+      setDbInfoText(`DB enthält ${res.data.rowCount} Artikel`);
+    } else if (res?.error) {
+      console.error('dbInfo failed', res.error);
+    }
   };
 
   const loadCategories = async () => {
-    const list = await window.bridge?.categories?.list();
-    setCategories(list || []);
+    const res = await window.bridge?.categories?.list();
+    if (res?.ok) {
+      setCategories(res.data);
+    } else if (res?.error) {
+      console.error('categories.list failed', res.error);
+      setCategories([]);
+    }
   };
 
   useEffect(() => {

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -1,67 +1,10 @@
+import type { Bridge, Api } from '../preload';
+
 declare global {
   interface Window {
-    bridge?: {
-      ready: boolean;
-      pickDatanormFile?: () => Promise<{ filePath: string; name: string } | null>;
-      importDatanorm?: (payload: {
-        filePath: string;
-        name?: string;
-        mapping?: any;
-        categoryId?: number;
-      }) => Promise<{ parsed: number; inserted: number; updated: number; durationMs: number }>;
-        searchArticles?: (opts: {
-          text?: string;
-          limit?: number;
-          offset?: number;
-          sortBy?: 'name' | 'articleNumber' | 'price';
-          sortDir?: 'ASC' | 'DESC';
-          categoryId?: number;
-        }) => Promise<{ items: any[]; total: number; message?: string }>;
-        searchAll?: (opts: {
-          text?: string;
-          limit?: number;
-          offset?: number;
-          sortBy?: 'name' | 'articleNumber' | 'price';
-          sortDir?: 'ASC' | 'DESC';
-          categoryId?: number;
-        }) => Promise<{
-          items: {
-            id?: number;
-            articleNumber?: string;
-            ean?: string;
-            name: string;
-            price?: number;
-            unit?: string;
-            productGroup?: string;
-            category_id?: number;
-            source: 'import' | 'custom';
-            imagePath?: string | null;
-          }[];
-          total: number;
-          message?: string;
-        }>;
-        customCreate?: (a: any) => Promise<{ id: number }>;
-        customUpdate?: (id: number, patch: any) => Promise<{ changes: number }>;
-        customDelete?: (id: number) => Promise<{ changes: number }>;
-        categories?: {
-          list: () => Promise<{ id: number; name: string }[]>;
-          create: (name: string) => Promise<{ id: number }>;
-          update: (id: number, name: string) => Promise<{ changes?: number; error?: string }>;
-          delete: (
-            id: number,
-            mode: 'reassign' | 'deleteArticles',
-            reassignToId?: number | null,
-          ) => Promise<{ deleted?: boolean; error?: string }>;
-        };
-        media?: {
-          addPrimary: (articleId: number, filePath: string, alt?: string) => Promise<any>;
-          list: (articleId: number) => Promise<any[]>;
-          remove: (mediaId: number) => Promise<any>;
-        };
-      dbInfo?: () => Promise<{ path: string; rowCount: number }>;
-      dbClear?: () => Promise<number>;
-      [key: string]: any;
-    };
+    bridge?: Bridge;
+    api?: Api;
   }
 }
+
 export {};

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -24,6 +24,16 @@ export const IPC_CHANNELS = {
     list: 'ipc.media.list',
     remove: 'ipc.media.remove',
   },
+  categories: {
+    list: 'categories:list',
+    create: 'categories:create',
+    update: 'categories:update',
+    delete: 'categories:delete',
+  },
+  db: {
+    info: 'db:info',
+    clear: 'db:clear',
+  },
   dialog: {
     open: 'ipc.dialog.open',
   },
@@ -31,6 +41,15 @@ export const IPC_CHANNELS = {
     open: 'ipc.shell.open',
   },
 } as const;
+
+export type IpcError = { code: string; message: string; details?: any };
+export type IpcResponse<T> = { ok: true; data: T } | { ok: false; error: IpcError };
+
+export const ok = <T>(data: T): IpcResponse<T> => ({ ok: true, data });
+export const err = (code: string, message: string, details?: any): IpcResponse<never> => ({
+  ok: false,
+  error: { code, message, details },
+});
 
 export const ImportResultSchema = z.object({ imported: z.number() });
 export const ImportProgressSchema = z.object({ processed: z.number(), total: z.number().optional() });

--- a/tests/ipcHandlers.spec.ts
+++ b/tests/ipcHandlers.spec.ts
@@ -1,0 +1,37 @@
+import type { IpcResponse } from '../src/shared/ipc';
+import { IPC_CHANNELS } from '../src/shared/ipc';
+import { registerIpcHandlers } from '../src/main/ipc/index';
+
+const handlers: Record<string, any> = {};
+jest.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, fn: any) => {
+      handlers[channel] = fn;
+    },
+  },
+}));
+
+jest.mock('../src/main/db', () => ({
+  getDbInfo: () => ({ path: '/tmp/test.db', rowCount: 5 }),
+  listCategories: () => [{ id: 1, name: 'Test' }],
+  clearArticles: () => 0,
+  createCategory: jest.fn(),
+  renameCategory: jest.fn(),
+  deleteCategory: jest.fn(),
+}));
+
+describe('IPC handlers', () => {
+  beforeAll(() => {
+    registerIpcHandlers();
+  });
+
+  test('db:info returns response schema', async () => {
+    const res: IpcResponse<any> = await handlers[IPC_CHANNELS.db.info]({});
+    expect(res).toEqual({ ok: true, data: { path: '/tmp/test.db', rowCount: 5 } });
+  });
+
+  test('categories:list returns response schema', async () => {
+    const res: IpcResponse<any> = await handlers[IPC_CHANNELS.categories.list]({});
+    expect(res).toEqual({ ok: true, data: [{ id: 1, name: 'Test' }] });
+  });
+});


### PR DESCRIPTION
## Summary
- register IPC handlers for `db:info` and `categories:list` and unify responses
- expose typed bridge in preload with IPC channel constants
- fix module loading to ensure handlers are registered

## Testing
- `npm test` *(fails: Missing local Node headers)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b894f8e2b08325ac1a16a1c1dd5c45