### PR TITLE
fix IPC preload path and handler registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev:renderer": "vite --config vite.config.mts",
     "dev:main": "wait-on http://localhost:5173 && electron ./dev-main.cjs",
     "build:main": "tsc -p tsconfig.main.json",
-    "build:preload": "tsc src/preload.ts --outDir build --module commonjs --target ES2020 --esModuleInterop",
+    "build:preload": "tsc src/preload.ts --outDir build --rootDir src --module commonjs --target ES2020 --esModuleInterop",
     "build:renderer": "vite build",
     "build": "npm run build:main && npm run build:preload && npm run build:renderer",
     "start": "electron .",

--- a/src/main/ipc/articles.ts
+++ b/src/main/ipc/articles.ts
@@ -25,7 +25,7 @@ export function registerArticlesHandlers() {
   });
   const UpsertMany = z.array(UpsertItem);
 
-  ipcMain.handle('articles:upsertMany', (_e, items) => {
+    ipcMain.handle(IPC_CHANNELS.articles.upsertMany, (_e, items) => {
     try {
       const parsed = UpsertMany.parse(items);
       const result = upsertArticles(parsed);

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -28,7 +28,7 @@ export function registerIpcHandlers() {
   registerMediaHandlers();
   registerArticlesHandlers();
 
-  ipcMain.handle('datanorm:import', async (_e, { filePath, mapping, categoryId }) => {
+  ipcMain.handle(IPC_CHANNELS.datanorm.import, async (_e, { filePath, mapping, categoryId }) => {
     const res = await importDatanormFile({ filePath, mapping, categoryId });
     console.log('Import result', res);
     return res;

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -20,8 +20,8 @@ const bridge = {
   ready: true,
   pickDatanormFile: () => ipcRenderer.invoke('dialog:pick-datanorm'),
   importDatanorm: (payload: DatanormImportPayload) =>
-    ipcRenderer.invoke('datanorm:import', payload),
-  searchArticles: (opts: any) => ipcRenderer.invoke('articles:search', opts),
+    ipcRenderer.invoke(IPC_CHANNELS.datanorm.import, payload),
+  searchArticles: (opts: any) => ipcRenderer.invoke(IPC_CHANNELS.articles.search, opts),
   searchAll: (opts: any) => ipcRenderer.invoke('articles:searchAll', opts),
   customCreate: (a: any) => ipcRenderer.invoke('custom:create', a),
   customUpdate: (id: number, patch: any) =>
@@ -41,9 +41,9 @@ const bridge = {
   },
   media: {
     addPrimary: (articleId: number, filePath: string, alt?: string) =>
-      ipcRenderer.invoke('media:addPrimary', { articleId, filePath, alt }),
-    list: (articleId: number) => ipcRenderer.invoke('media:list', { articleId }),
-    remove: (mediaId: number) => ipcRenderer.invoke('media:remove', { mediaId }),
+      ipcRenderer.invoke(IPC_CHANNELS.media.addPrimary, { articleId, filePath, alt }),
+    list: (articleId: number) => ipcRenderer.invoke(IPC_CHANNELS.media.list, { articleId }),
+    remove: (mediaId: number) => ipcRenderer.invoke(IPC_CHANNELS.media.remove, { mediaId }),
   },
   dbInfo: (): Promise<IpcResponse<{ path: string; rowCount: number }>> =>
     ipcRenderer.invoke(IPC_CHANNELS.db.info),
@@ -76,7 +76,7 @@ const api = {
   },
   articles: {
     upsertMany: (items: any[]) =>
-      ipcRenderer.invoke('articles:upsertMany', items) as Promise<
+      ipcRenderer.invoke(IPC_CHANNELS.articles.upsertMany, items) as Promise<
         | { ok: true; inserted: number; updated: number }
         | { ok: false; code?: string; message: string; details?: any }
       >,


### PR DESCRIPTION
## Summary
- ensure preload build keeps shared IPC module relative paths
- use IPC_CHANNELS constants for datanorm import, article search/upsert, and media operations
- register main-process handlers with matching IPC_CHANNELS

## Testing
- `npm run build:preload`
- `npm run typecheck`
- `npm test` *(fails: Fehlende lokale Node-Header/Lib)*

------
https://chatgpt.com/codex/tasks/task_e_68b898a064648325891746cf69d6bbba