### PR TITLE
fix(db): robust upsert with named parameters

### DIFF
--- a/src/main/datanorm/parser.ts
+++ b/src/main/datanorm/parser.ts
@@ -108,7 +108,7 @@ export async function importDatanormFile({
     return item;
   });
 
-  const { inserted, updated } = upsertArticles(arr);
+  const res = upsertArticles(arr);
   const durationMs = Date.now() - start;
-  return { parsed: arr.length, inserted, updated, durationMs };
+  return { parsed: arr.length, inserted: res.count, updated: 0, durationMs };
 }


### PR DESCRIPTION
## Summary
- ensure articles schema includes `updated_at` and unique `articleNumber` index
- refactor `upsertArticles` to use named parameters and log schema for debugging
- return structured results in `articles:upsertMany` handler

## Testing
- `npm run typecheck`
- `npm test` *(fails: Fehlende lokale Node-Header/Lib: C:/node-headers/v20.19.4/include/node/node_api.h)*
- `sqlite3 :memory: "CREATE TABLE IF NOT EXISTS categories (id INTEGER PRIMARY KEY, name TEXT NOT NULL UNIQUE); CREATE TABLE IF NOT EXISTS articles (id INTEGER PRIMARY KEY, articleNumber TEXT NOT NULL, ean TEXT, name TEXT, price REAL, unit TEXT, productGroup TEXT, category_id INTEGER, updated_at INTEGER, FOREIGN KEY (category_id) REFERENCES categories(id)); CREATE UNIQUE INDEX IF NOT EXISTS idx_articles_articlenumber ON articles(articleNumber); PRAGMA table_info(articles); PRAGMA index_list(articles);"`

------
https://chatgpt.com/codex/tasks/task_e_68b8a00345048325a20818ccb5f4205a