### PR TITLE
chore: add dump-schema script

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "test": "ts-node -T scripts/run-tests-with-local-headers.ts",
     "test:unit": "ts-node -T scripts/run-tests-with-local-headers.ts",
     "test:file": "ts-node -T scripts/run-tests-with-local-headers.ts",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "dump-schema": "ts-node scripts/dump-schema.ts"
   },
   "dependencies": {
     "electron-updater": "^6.1.1",


### PR DESCRIPTION
## Summary
- add dump-schema npm script to run schema dumping
- ensure TypeScript utilities ts-node and typescript are listed as dev dependencies

## Testing
- `npm test` *(fails: Missing local Node headers)*

------
https://chatgpt.com/codex/tasks/task_e_68b94736df288325bc548dd818850438