### PR TITLE
fix(db/fts): ensure contentless FTS5 table for articles

### DIFF
--- a/src/main/db.migrations.ts
+++ b/src/main/db.migrations.ts
@@ -64,4 +64,95 @@ export function ensureSchema(db: Database) {
   });
 
   run(); // Transaktion ausführen
+
+  ensureFts(db);
+  backfillArticlesFts(db);
+}
+
+/**
+ * Stellt die contentless FTS5-Tabelle und die zugehörigen Trigger für 'articles' idempotent her.
+ */
+function ensureFts(db: Database) {
+  // Prüfen, ob FTS5 verfügbar ist (optional, aber hilfreich fürs Log)
+  try {
+    db.prepare("SELECT 1 FROM pragma_compile_options WHERE compile_options LIKE 'FTS5%'").get();
+  } catch {
+    /* ignore – manche Builds führen das nicht */
+  }
+
+  // Existenz der FTS-Tabelle prüfen
+  const fts = db
+    .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='articles_fts'")
+    .get();
+
+  // In einer Transaktion alles sauber herstellen
+  db.transaction(() => {
+    if (!fts) {
+      // Contentless FTS5 (keine 'content=' Verknüpfung; Trigger pflegen Index manuell)
+      db.exec(`
+        CREATE VIRTUAL TABLE IF NOT EXISTS articles_fts
+        USING fts5(
+          articleNumber,
+          name,
+          ean,
+          category_name,
+          content=''
+        );
+      `);
+    } else {
+      // Optional: Schema der FTS-Spalten prüfen (pragma fts5vocab) – bei Abweichung neu erstellen
+      // Vereinfachung: wir gehen von passendem Schema aus oder recreaten über DROP/CREATE falls nötig.
+    }
+
+    // Trigger immer deterministisch neu anlegen
+    db.exec(`
+      DROP TRIGGER IF EXISTS articles_ai;
+      DROP TRIGGER IF EXISTS articles_au;
+      DROP TRIGGER IF EXISTS articles_ad;
+
+      CREATE TRIGGER articles_ai AFTER INSERT ON articles BEGIN
+        INSERT INTO articles_fts(rowid, articleNumber, name, ean, category_name)
+        VALUES (
+          new.id,
+          new.articleNumber,
+          new.name,
+          new.ean,
+          (SELECT name FROM categories WHERE id = new.category_id)
+        );
+      END;
+
+      CREATE TRIGGER articles_au AFTER UPDATE ON articles BEGIN
+        INSERT INTO articles_fts(articles_fts, rowid) VALUES('delete', old.id);
+        INSERT INTO articles_fts(rowid, articleNumber, name, ean, category_name)
+        VALUES (
+          new.id,
+          new.articleNumber,
+          new.name,
+          new.ean,
+          (SELECT name FROM categories WHERE id = new.category_id)
+        );
+      END;
+
+      CREATE TRIGGER articles_ad AFTER DELETE ON articles BEGIN
+        INSERT INTO articles_fts(articles_fts, rowid) VALUES('delete', old.id);
+      END;
+    `);
+  })();
+}
+
+// optionaler Backfill – einmalig nach ensureFts(db)
+function backfillArticlesFts(db: Database) {
+  const count = db.prepare("SELECT COUNT(*) AS c FROM articles_fts").get()?.c ?? 0;
+  if (count > 0) return; // schon befüllt
+
+  db.exec(`
+    INSERT INTO articles_fts(rowid, articleNumber, name, ean, category_name)
+    SELECT
+      a.id,
+      a.articleNumber,
+      a.name,
+      a.ean,
+      (SELECT name FROM categories WHERE id = a.category_id)
+    FROM articles a;
+  `);
 }


### PR DESCRIPTION
## Summary
- create contentless FTS5 table `articles_fts`
- drop and recreate triggers for articles to keep FTS index in sync
- backfill FTS index when empty

## Testing
- `npm run typecheck`
- `npm test` *(fails: Missing local Node headers/Lib)*

------
https://chatgpt.com/codex/tasks/task_e_68b95ac4ccb08325813266aad60c2bad