### PR TITLE
fix: allow duplicate article numbers

### DIFF
--- a/src/main/db.migrations.ts
+++ b/src/main/db.migrations.ts
@@ -50,7 +50,7 @@ export function ensureSchema(db: Database) {
 
     // Indizes sicherstellen (idempotent)
     db.exec(`
-      CREATE UNIQUE INDEX IF NOT EXISTS idx_articles_articlenumber
+      CREATE INDEX IF NOT EXISTS idx_articles_articlenumber
         ON articles(articleNumber);
       CREATE INDEX IF NOT EXISTS idx_articles_ean ON articles(ean);
       CREATE INDEX IF NOT EXISTS idx_articles_updated_at ON articles(updated_at);

--- a/src/main/db.ts
+++ b/src/main/db.ts
@@ -11,6 +11,10 @@ export const dbPath = path.join(dataDir, 'app-data.db');
 console.log('DB path:', dbPath);
 const db = new Database(dbPath);
 ensureSchema(db);
+console.debug(
+  "[db] index_list('articles') =>",
+  db.prepare("PRAGMA index_list('articles')").all(),
+);
 console.log('Schema OK');
 
 export const mediaRoot = path.join(app.getPath('userData'), 'media');

--- a/tests/migrations.spec.ts
+++ b/tests/migrations.spec.ts
@@ -15,7 +15,9 @@ describe('ensureSchema', () => {
     const version2 = db.pragma('user_version', { simple: true }) as number;
     expect(version1).toBe(1);
     expect(version2).toBe(1);
-    const idx = db.prepare("PRAGMA index_list('articles')").all();
-    expect(idx.find((i: any) => i.name === 'idx_articles_articlenumber')).toBeTruthy();
+    const idx = db.prepare("PRAGMA index_list('articles')").all() as any[];
+    const articleIdx = idx.find((i: any) => i.name === 'idx_articles_articlenumber');
+    expect(articleIdx).toBeTruthy();
+    expect(articleIdx.unique).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- drop uniqueness for articles.articleNumber index
- log index list after schema setup to verify non-unique
- ensure migrations test checks for non-unique article number index

## Testing
- `npm test` *(fails: Fehlende lokale Node-Header/Lib)*
- `npm run build:preload`


------
https://chatgpt.com/codex/tasks/task_e_68b979cae38c8325be96764192660797