### PR TITLE
Add import wizard progress and result flow

### DIFF
--- a/src/main/ipc/import.ts
+++ b/src/main/ipc/import.ts
@@ -3,16 +3,25 @@ import { IPC_CHANNELS, ok, err } from '../../shared/ipc';
 import { importArticles } from '../services/articlesImportService';
 
 export function registerImportHandlers() {
+  let cancelled = false;
+
   ipcMain.handle(IPC_CHANNELS.import.run, (event, payload) => {
+    cancelled = false;
     try {
       const summary = importArticles({
         rows: payload.rows,
         dryRun: payload.dryRun,
         onProgress: (p) => event.sender.send(IPC_CHANNELS.import.progress, p),
+        shouldCancel: () => cancelled,
       });
-      return ok(summary);
+      return ok({ ...summary, cancelled });
     } catch (e: any) {
       return err('IMPORT_FAILED', e.message);
     }
+  });
+
+  ipcMain.handle(IPC_CHANNELS.import.cancel, () => {
+    cancelled = true;
+    return ok(true);
   });
 }

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -1,4 +1,4 @@
-import { ipcMain, dialog } from 'electron';
+import { ipcMain, dialog, BrowserWindow } from 'electron';
 import path from 'path';
 import { importDatanormFile } from '../datanorm/parser';
 import {
@@ -29,6 +29,10 @@ export function registerIpcHandlers() {
   registerMediaHandlers();
   registerArticlesHandlers();
   registerImportHandlers();
+
+  ipcMain.handle(IPC_CHANNELS.devtools.open, () => {
+    BrowserWindow.getFocusedWindow()?.webContents.openDevTools({ mode: 'undocked' });
+  });
 
   ipcMain.handle(IPC_CHANNELS.datanorm.import, async (_e, { filePath, mapping, categoryId }) => {
     const res = await importDatanormFile({ filePath, mapping, categoryId });

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -84,7 +84,14 @@ const api = {
   import: {
     run: (payload: { rows: any[]; dryRun?: boolean }) =>
       ipcRenderer.invoke(IPC_CHANNELS.import.run, payload),
+    onProgress: (handler: (p: { processed: number; total: number }) => void) => {
+      const listener = (_e: any, data: any) => handler(data);
+      ipcRenderer.on(IPC_CHANNELS.import.progress, listener);
+      return () => ipcRenderer.removeListener(IPC_CHANNELS.import.progress, listener);
+    },
+    cancel: () => ipcRenderer.invoke(IPC_CHANNELS.import.cancel),
   },
+  openDevTools: () => ipcRenderer.invoke(IPC_CHANNELS.devtools.open),
 };
 
 try {

--- a/src/renderer/features/import/StepPreview.tsx
+++ b/src/renderer/features/import/StepPreview.tsx
@@ -1,42 +1,138 @@
-import React from 'react';
-import type { ImportRow } from './types';
+import React, { useEffect, useState } from 'react';
+import type { ImportRow, ImportSummary } from './types';
 
-type Props = {
+interface Props {
   rows: ImportRow[];
   onBack: () => void;
-  onImport: (dryRun?: boolean) => void;
-};
+  onCancel: () => void;
+  onComplete: (summary: ImportSummary, cancelled: boolean) => void;
+}
 
-const StepPreview: React.FC<Props> = ({ rows, onBack, onImport }) => {
+const StepPreview: React.FC<Props> = ({ rows, onBack, onCancel, onComplete }) => {
   const headers = rows[0] ? Object.keys(rows[0]) : [];
   const sample = rows.slice(0, 100);
+  const [isImporting, setImporting] = useState(false);
+  const [progress, setProgress] = useState<{ processed: number; total: number }>({
+    processed: 0,
+    total: rows.length,
+  });
+  const [start, setStart] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!isImporting) return;
+    const log = (() => {
+      let last = 0;
+      return (p: { processed: number; total: number }) => {
+        const now = Date.now();
+        if (now - last > 1000) {
+          console.debug('import progress', p);
+          last = now;
+        }
+        setProgress(p);
+      };
+    })();
+    const unsub = window.api.import.onProgress(log);
+    return () => {
+      unsub();
+    };
+  }, [isImporting]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Enter' && !isImporting) startImport();
+      if (e.key === 'Escape' && !isImporting) handleCancel();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [isImporting]);
+
+  function handleCancel() {
+    if (isImporting) {
+      window.api.import.cancel();
+    } else {
+      if (window.confirm('Import abbrechen?')) onCancel();
+    }
+  }
+
+  async function startImport() {
+    console.info('Import gestartet');
+    setStart(Date.now());
+    setImporting(true);
+    try {
+      const res: any = await window.api.import.run({ rows });
+      if (res?.ok) {
+        console.info('Import beendet');
+        onComplete(res.data, res.data.cancelled === true);
+      } else {
+        console.error('Import fehlgeschlagen', res?.error);
+        alert(res?.error?.message || 'Import fehlgeschlagen');
+        window.api.openDevTools();
+        onCancel();
+      }
+    } catch (e: any) {
+      console.error('Import Fehler', e);
+      alert(e?.message || e);
+      window.api.openDevTools();
+      onCancel();
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  const eta = (() => {
+    if (!isImporting || !start) return '';
+    const elapsed = Date.now() - start;
+    const rate = progress.processed / elapsed;
+    if (!rate) return '';
+    const remaining = (progress.total - progress.processed) / rate;
+    const sec = Math.round(remaining / 1000);
+    return ` (${sec}s)`;
+  })();
 
   return (
-    <div>
-      <table>
-        <thead>
-          <tr>
-            {headers.map((h) => (
-              <th key={h}>{h}</th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {sample.map((r, i) => (
-            <tr key={i}>
+    <div className={isImporting ? 'loading' : ''}>
+      <div className="with-footer">
+        <table>
+          <thead>
+            <tr>
               {headers.map((h) => (
-                <td key={h}>{(r as any)[h]}</td>
+                <th key={h}>{h}</th>
               ))}
             </tr>
-          ))}
-        </tbody>
-      </table>
-      <div className="modal-actions">
-        <button onClick={onBack}>Zurück</button>
-        <button className="primary" onClick={() => onImport(false)}>
+          </thead>
+          <tbody>
+            {sample.map((r, i) => (
+              <tr key={i}>
+                {headers.map((h) => (
+                  <td key={h}>{(r as any)[h]}</td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {isImporting && (
+        <div>
+          <progress value={progress.processed} max={progress.total}></progress>
+          <span>
+            {progress.processed} / {progress.total}
+            {eta}
+          </span>
+        </div>
+      )}
+      <div className="wizard-footer" role="toolbar">
+        <button onClick={onBack} disabled={isImporting} aria-disabled={isImporting}>
+          Zurück
+        </button>
+        <button onClick={handleCancel}>Abbrechen</button>
+        <button
+          className="primary"
+          onClick={startImport}
+          disabled={isImporting}
+          aria-disabled={isImporting}
+        >
           Import starten
         </button>
-        <button onClick={() => onImport(true)}>Dry-Run</button>
       </div>
     </div>
   );

--- a/src/renderer/features/import/StepResult.tsx
+++ b/src/renderer/features/import/StepResult.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import type { ImportSummary } from './types';
+
+interface Props {
+  summary: ImportSummary;
+  cancelled: boolean;
+  onClose: () => void;
+  onRestart: () => void;
+}
+
+const StepResult: React.FC<Props> = ({ summary, cancelled, onClose, onRestart }) => {
+  const { total, inserted, updated, skipped, errors } = summary;
+
+  const exportErrors = () => {
+    const header = 'rowIndex,articleNumber,message\n';
+    const rows = errors
+      .map((e) =>
+        `${e.rowIndex + 1},${e.articleNumber || ''},"${(e.message || '').replace(/"/g, '""')}"`,
+      )
+      .join('\n');
+    const blob = new Blob([header + rows], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'import-errors.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div>
+      {cancelled ? (
+        <p>Import abgebrochen.</p>
+      ) : (
+        <div className="summary">
+          <div className="badge">Total: {total}</div>
+          <div className="badge">Inserted: {inserted}</div>
+          <div className="badge">Updated: {updated}</div>
+          <div className="badge">Skipped: {skipped}</div>
+          <div className="badge">Errors: {errors.length}</div>
+        </div>
+      )}
+      {!cancelled && errors.length > 0 && (
+        <button onClick={exportErrors}>Fehler als CSV exportieren</button>
+      )}
+      <div className="wizard-footer" role="toolbar">
+        {cancelled ? (
+          <>
+            <button onClick={onRestart}>Erneut versuchen</button>
+            <button className="primary" onClick={onClose}>
+              Schließen
+            </button>
+          </>
+        ) : (
+          <>
+            <button onClick={onRestart}>Erneut importieren</button>
+            <button className="primary" onClick={onClose}>
+              Fertig
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default StepResult;

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -125,6 +125,37 @@ fieldset > label {
   gap: 10px;
   margin-top: 12px;
 }
+
+.wizard-footer {
+  position: sticky;
+  bottom: 0;
+  background: #fff;
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding-top: 8px;
+  border-top: 1px solid #ccc;
+}
+
+.with-footer {
+  padding-bottom: 60px;
+}
+
+.loading {
+  cursor: progress;
+}
+
+.summary {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.summary .badge {
+  background: #eee;
+  padding: 8px 12px;
+  border-radius: 4px;
+}
 .primary {
   background: #1f6feb;
   color: #fff;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -27,6 +27,10 @@ export const IPC_CHANNELS = {
   import: {
     run: 'ipc.import.run',
     progress: 'ipc.import.progress',
+    cancel: 'ipc.import.cancel',
+  },
+  devtools: {
+    open: 'devtools:open',
   },
   categories: {
     list: 'categories:list',

--- a/tests/ipcHandlers.spec.ts
+++ b/tests/ipcHandlers.spec.ts
@@ -9,6 +9,9 @@ jest.mock('electron', () => ({
       handlers[channel] = fn;
     },
   },
+  BrowserWindow: {
+    getFocusedWindow: () => ({ webContents: { openDevTools: jest.fn() } }),
+  },
 }));
 
 jest.mock('../src/main/db', () => ({


### PR DESCRIPTION
## Summary
- add progress-aware preview step with cancel and import actions
- expose import progress & cancel IPC handlers
- show import summary and error export after completion

## Testing
- `npm test` *(fails: Fehlende lokale Node-Header/Lib)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b9dca48b6c8325a9ced2f7e62e9926