### PR TITLE
feat: allow partial import mapping

### DIFF
--- a/src/main/services/articlesImportService.ts
+++ b/src/main/services/articlesImportService.ts
@@ -1,8 +1,17 @@
 import { db } from '../db';
-import type { ArticleRow } from '../db';
+
+export interface ImportRow {
+  articleNumber: string;
+  ean?: string | null;
+  name?: string | null;
+  price?: number | null;
+  unit?: string | null;
+  productGroup?: string | null;
+  category?: string | null;
+}
 
 export interface ImportArgs {
-  rows: ArticleRow[];
+  rows: ImportRow[];
   dryRun?: boolean;
   onProgress?: (p: { processed: number; total: number }) => void;
   shouldCancel?: () => boolean;
@@ -16,29 +25,59 @@ export interface ImportSummary {
   errors: { rowIndex: number; articleNumber?: string; message: string }[];
 }
 
+function resolveCategoryId(cat: string | null | undefined): number | null {
+  if (!cat) return null;
+  const num = Number(cat);
+  if (!Number.isNaN(num)) return num;
+  const trimmed = String(cat).trim();
+  const found = db.prepare('SELECT id FROM categories WHERE name=?').get(trimmed) as
+    | { id: number }
+    | undefined;
+  if (found) return found.id;
+  const res = db.prepare('INSERT INTO categories (name) VALUES (?)').run(trimmed);
+  return Number(res.lastInsertRowid);
+}
+
 export function importArticles({ rows, dryRun = false, onProgress, shouldCancel }: ImportArgs): ImportSummary {
   const total = rows.length;
   const summary: ImportSummary = { total, inserted: 0, updated: 0, skipped: 0, errors: [] };
   if (dryRun || total === 0) return summary;
 
-  const stmt = db.prepare(`
-INSERT INTO articles (
-  articleNumber, ean, name, price, unit, productGroup, category_id, updated_at
-) VALUES (
-  @articleNumber, @ean, @name, @price, @unit, @productGroup, @category_id, CURRENT_TIMESTAMP
-)
-ON CONFLICT(articleNumber) DO UPDATE SET
-  ean=excluded.ean,
-  name=excluded.name,
-  price=excluded.price,
-  unit=excluded.unit,
-  productGroup=excluded.productGroup,
-  category_id=excluded.category_id,
-  updated_at=excluded.updated_at
-`);
+  const processedRows = rows.map((r) => {
+    const out: Record<string, unknown> = { articleNumber: r.articleNumber };
+    if ('ean' in r) out.ean = r.ean ?? null;
+    if ('name' in r) out.name = r.name ?? null;
+    if ('price' in r) out.price = r.price ?? null;
+    if ('unit' in r) out.unit = r.unit ?? null;
+    if ('productGroup' in r) out.productGroup = r.productGroup ?? null;
+    if ('category' in r) out.category_id = resolveCategoryId(r.category ?? null);
+    return out as Record<string, unknown> & { articleNumber: string };
+  });
+
+  const fieldSet = new Set<string>();
+  processedRows.forEach((r) => {
+    Object.keys(r).forEach((k) => {
+      if (k !== 'articleNumber') fieldSet.add(k);
+    });
+  });
+  const fields = Array.from(fieldSet);
+
+  processedRows.forEach((r) => {
+    fields.forEach((f) => {
+      if (!(f in r)) (r as Record<string, unknown>)[f] = null;
+    });
+  });
+
+  const columns = ['articleNumber', ...fields, 'updated_at'];
+  const values = ['@articleNumber', ...fields.map((f) => `@${f}`), 'CURRENT_TIMESTAMP'];
+  const updates = fields.map((f) => `${f}=excluded.${f}`).concat('updated_at=excluded.updated_at');
+  const stmt = db.prepare(
+    `INSERT INTO articles (${columns.join(',')}) VALUES (${values.join(',')}) ON CONFLICT(articleNumber) DO UPDATE SET ${updates.join(',')}`,
+  );
+
   const exists = db.prepare('SELECT 1 FROM articles WHERE articleNumber = ?');
 
-  const tx = db.transaction((all: ArticleRow[]) => {
+  const tx = db.transaction((all: typeof processedRows) => {
     let processed = 0;
     const CHUNK = 500;
     for (let i = 0; i < all.length; i += CHUNK) {
@@ -48,7 +87,8 @@ ON CONFLICT(articleNumber) DO UPDATE SET
         try {
           const was = exists.get(r.articleNumber);
           stmt.run(r);
-          if (was) summary.updated += 1; else summary.inserted += 1;
+          if (was) summary.updated += 1;
+          else summary.inserted += 1;
         } catch (e: any) {
           summary.errors.push({ rowIndex: i + idx, articleNumber: r.articleNumber, message: e.message });
           summary.skipped += 1;
@@ -60,7 +100,7 @@ ON CONFLICT(articleNumber) DO UPDATE SET
     }
   });
 
-  tx(rows);
+  tx(processedRows);
 
   return summary;
 }

--- a/src/renderer/features/import/ImportWizard.tsx
+++ b/src/renderer/features/import/ImportWizard.tsx
@@ -3,14 +3,19 @@ import StepFile from './StepFile';
 import StepMapping from './StepMapping';
 import StepPreview from './StepPreview';
 import StepResult from './StepResult';
-import type { ParsedFile, ImportRow, Mapping, ImportSummary } from './types';
+import type {
+  ParsedFile,
+  RawImportRow,
+  Mapping,
+  ImportSummary,
+} from './types';
 
 type Props = { open: boolean; onClose: () => void };
 
 const ImportWizard: React.FC<Props> = ({ open, onClose }) => {
   const [step, setStep] = useState(0);
   const [parsed, setParsed] = useState<ParsedFile | null>(null);
-  const [rows, setRows] = useState<ImportRow[]>([]);
+  const [rows, setRows] = useState<RawImportRow[]>([]);
   const [mapping, setMapping] = useState<Mapping>({});
   const [summary, setSummary] = useState<ImportSummary | null>(null);
   const [cancelled, setCancelled] = useState(false);
@@ -22,7 +27,7 @@ const ImportWizard: React.FC<Props> = ({ open, onClose }) => {
     setStep(1);
   };
 
-  const handleMapped = (r: ImportRow[], m: Mapping) => {
+  const handleMapped = (r: RawImportRow[], m: Mapping) => {
     setRows(r);
     setMapping(m);
     setStep(2);
@@ -63,6 +68,7 @@ const ImportWizard: React.FC<Props> = ({ open, onClose }) => {
         {step === 2 && (
           <StepPreview
             rows={rows}
+            mapping={mapping}
             onBack={() => setStep(1)}
             onCancel={handleCancel}
             onComplete={handleComplete}

--- a/src/renderer/features/import/types.ts
+++ b/src/renderer/features/import/types.ts
@@ -3,12 +3,31 @@ export type ParsedFile = {
   rows: any[][];
 };
 
-export type Mapping = Record<string, string>;
+export type MappingField =
+  | 'articleNumber'
+  | 'ean'
+  | 'name'
+  | 'price'
+  | 'unit'
+  | 'productGroup'
+  | 'category';
+
+export type Mapping = Partial<Record<MappingField, string | null>>;
+
+export type RawImportRow = {
+  articleNumber: unknown;
+  ean?: unknown;
+  name?: unknown;
+  price?: unknown;
+  unit?: unknown;
+  productGroup?: unknown;
+  category?: unknown;
+};
 
 export type ImportRow = {
   articleNumber: string;
   ean?: string | null;
-  name: string;
+  name?: string | null;
   price?: number | null;
   unit?: string | null;
   productGroup?: string | null;

--- a/src/renderer/features/import/validators.ts
+++ b/src/renderer/features/import/validators.ts
@@ -8,3 +8,75 @@ export function normalizePrice(v: unknown): number | null {
   const num = parseFloat(s);
   return isNaN(num) ? null : num;
 }
+
+import type { RawImportRow, ImportRow, Mapping } from './types';
+
+export type RowIssue = { rowIndex: number; warnings: string[]; errors: string[] };
+
+export function validateRows(rows: RawImportRow[], mapping: Mapping) {
+  const issues: RowIssue[] = [];
+  const result: ImportRow[] = [];
+  const stats = { ok: 0, warn: 0, error: 0 };
+  const seen = new Set<string>();
+
+  rows.forEach((r, idx) => {
+    const warnings: string[] = [];
+    const errors: string[] = [];
+
+    const articleNumber = normalizeString(r.articleNumber);
+    if (!articleNumber) {
+      errors.push('Artikelnummer fehlt');
+    } else if (seen.has(articleNumber)) {
+      errors.push('Artikelnummer doppelt');
+    } else {
+      seen.add(articleNumber);
+    }
+
+    const row: ImportRow = { articleNumber };
+
+    if (mapping.ean !== undefined && mapping.ean !== null) {
+      const ean = normalizeString(r.ean);
+      row.ean = ean || null;
+    }
+
+    if (mapping.name !== undefined && mapping.name !== null) {
+      const name = normalizeString(r.name);
+      if (!name) warnings.push('Name fehlt, wird als leer gespeichert');
+      row.name = name || null;
+    } else {
+      warnings.push('Name nicht gesetzt (leer gespeichert)');
+    }
+
+    if (mapping.price !== undefined && mapping.price !== null) {
+      const parsed = normalizePrice(r.price);
+      if (parsed === null && normalizeString(r.price).length > 0) {
+        errors.push('Preis ungültig');
+      }
+      row.price = parsed;
+    }
+
+    if (mapping.unit !== undefined && mapping.unit !== null) {
+      const unit = normalizeString(r.unit);
+      row.unit = unit || null;
+    }
+
+    if (mapping.productGroup !== undefined && mapping.productGroup !== null) {
+      const pg = normalizeString(r.productGroup);
+      row.productGroup = pg || null;
+    }
+
+    if (mapping.category !== undefined && mapping.category !== null) {
+      const cat = normalizeString(r.category);
+      row.category = cat || null;
+    }
+
+    issues.push({ rowIndex: idx, warnings, errors });
+    if (errors.length > 0) stats.error += 1;
+    else if (warnings.length > 0) stats.warn += 1;
+    else stats.ok += 1;
+
+    result.push(row);
+  });
+
+  return { rows: result, issues, stats };
+}


### PR DESCRIPTION
## Summary
- allow leaving non-required fields unmapped in import wizard
- validate only mapped columns and surface warnings instead of hard errors
- build dynamic upsert statements that write only mapped fields

## Testing
- `npm run typecheck`
- `npm test` *(fails: Fehlende lokale Node-Header/Lib)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e2c446e0832587aa7d13020a84e9