### PR TITLE
Support partial article imports

### DIFF
--- a/src/main/ipc/import.ts
+++ b/src/main/ipc/import.ts
@@ -14,7 +14,7 @@ export function registerImportHandlers() {
         onProgress: (p) => event.sender.send(IPC_CHANNELS.import.progress, p),
         shouldCancel: () => cancelled,
       });
-      return ok({ ...summary, cancelled });
+      return ok(summary);
     } catch (e: any) {
       return err('IMPORT_FAILED', e.message);
     }

--- a/src/main/services/articlesImportService.ts
+++ b/src/main/services/articlesImportService.ts
@@ -1,4 +1,5 @@
-import { db } from '../db';
+import { db, type ArticleRow } from '../db';
+type Statement = ReturnType<typeof db.prepare>;
 
 export interface ImportRow {
   articleNumber: string;
@@ -19,88 +20,213 @@ export interface ImportArgs {
 
 export interface ImportSummary {
   total: number;
+  processed: number;
   inserted: number;
   updated: number;
   skipped: number;
   errors: { rowIndex: number; articleNumber?: string; message: string }[];
+  cancelled: boolean;
 }
 
-function resolveCategoryId(cat: string | null | undefined): number | null {
-  if (!cat) return null;
+function resolveCategory(
+  cat: string | null | undefined,
+): { id: number | null; name: string | null } {
+  if (!cat) return { id: null, name: null };
   const num = Number(cat);
-  if (!Number.isNaN(num)) return num;
+  if (!Number.isNaN(num)) return { id: num, name: null };
   const trimmed = String(cat).trim();
-  const found = db.prepare('SELECT id FROM categories WHERE name=?').get(trimmed) as
-    | { id: number }
-    | undefined;
-  if (found) return found.id;
+  const found = db
+    .prepare('SELECT id FROM categories WHERE name=?')
+    .get(trimmed) as { id: number } | undefined;
+  if (found) return { id: found.id, name: trimmed };
   const res = db.prepare('INSERT INTO categories (name) VALUES (?)').run(trimmed);
-  return Number(res.lastInsertRowid);
+  return { id: Number(res.lastInsertRowid), name: trimmed };
 }
 
-export function importArticles({ rows, dryRun = false, onProgress, shouldCancel }: ImportArgs): ImportSummary {
+export function buildUpsertForRow(mappedRow: Partial<ArticleRow>) {
+  if (!('articleNumber' in mappedRow)) throw new Error('articleNumber required');
+  const cols = Object.keys(mappedRow) as (keyof ArticleRow)[];
+  const insertCols = [...cols, 'updated_at'];
+  const values = [...cols.map((c) => `@${c}`), 'CURRENT_TIMESTAMP'];
+  const updateCols = cols.filter((c) => c !== 'articleNumber');
+  const updates = [
+    ...updateCols.map((c) => `${String(c)}=excluded.${String(c)}`),
+    'updated_at=excluded.updated_at',
+  ];
+  const params = cols.reduce<Record<string, unknown>>((acc, c) => {
+    acc[c] = (mappedRow as Record<string, unknown>)[c];
+    return acc;
+  }, {});
+  const sql = `INSERT INTO articles (${insertCols.join(',')}) VALUES (${values.join(',')}) ON CONFLICT(articleNumber) DO UPDATE SET ${updates.join(',')}`;
+  return { sql, params, columns: insertCols, updateCols };
+}
+
+export function importArticles({
+  rows,
+  dryRun = false,
+  onProgress,
+  shouldCancel,
+}: ImportArgs): ImportSummary {
   const total = rows.length;
-  const summary: ImportSummary = { total, inserted: 0, updated: 0, skipped: 0, errors: [] };
+  const summary: ImportSummary = {
+    total,
+    processed: 0,
+    inserted: 0,
+    updated: 0,
+    skipped: 0,
+    errors: [],
+    cancelled: false,
+  };
   if (dryRun || total === 0) return summary;
 
-  const processedRows = rows.map((r) => {
-    const out: Record<string, unknown> = { articleNumber: r.articleNumber };
-    if ('ean' in r) out.ean = r.ean ?? null;
-    if ('name' in r) out.name = r.name ?? null;
-    if ('price' in r) out.price = r.price ?? null;
-    if ('unit' in r) out.unit = r.unit ?? null;
-    if ('productGroup' in r) out.productGroup = r.productGroup ?? null;
-    if ('category' in r) out.category_id = resolveCategoryId(r.category ?? null);
-    return out as Record<string, unknown> & { articleNumber: string };
-  });
+  try {
+    const tableInfo = db.prepare('PRAGMA table_info(articles)').all() as {
+      name: string;
+      notnull: number;
+      type: string;
+    }[];
+    const idxList = db.prepare('PRAGMA index_list(articles)').all() as { name: string }[];
+    console.debug(
+      '[import] table_info(articles) =>',
+      tableInfo.map((c) => ({ name: c.name, notnull: c.notnull, type: c.type })),
+    );
+    console.debug('[import] index_list(articles) =>', idxList);
+  } catch (e) {
+    console.warn('[import] pragma failed', e);
+  }
 
-  const fieldSet = new Set<string>();
-  processedRows.forEach((r) => {
-    Object.keys(r).forEach((k) => {
-      if (k !== 'articleNumber') fieldSet.add(k);
-    });
-  });
-  const fields = Array.from(fieldSet);
+  const existsStmt = db.prepare('SELECT rowid FROM articles WHERE articleNumber=?');
 
-  processedRows.forEach((r) => {
-    fields.forEach((f) => {
-      if (!(f in r)) (r as Record<string, unknown>)[f] = null;
-    });
-  });
+  const hasFts = !!db
+    .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='articles_fts'")
+    .get();
+  const triggers = hasFts
+    ? db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type='trigger' AND tbl_name='articles' AND name LIKE '%articles_fts%'",
+        )
+        .all()
+    : [];
+  const useFTSDirectWrite = hasFts && triggers.length === 0;
 
-  const columns = ['articleNumber', ...fields, 'updated_at'];
-  const values = ['@articleNumber', ...fields.map((f) => `@${f}`), 'CURRENT_TIMESTAMP'];
-  const updates = fields.map((f) => `${f}=excluded.${f}`).concat('updated_at=excluded.updated_at');
-  const stmt = db.prepare(
-    `INSERT INTO articles (${columns.join(',')}) VALUES (${values.join(',')}) ON CONFLICT(articleNumber) DO UPDATE SET ${updates.join(',')}`,
-  );
+  let deleteFts: Statement | undefined;
+  let insertFts: Statement | undefined;
+  let ftsCols: string[] = [];
 
-  const exists = db.prepare('SELECT 1 FROM articles WHERE articleNumber = ?');
+  if (useFTSDirectWrite) {
+    const info = db.prepare('PRAGMA table_info(articles_fts)').all() as { name: string }[];
+    const desired = [
+      'articleNumber',
+      'name',
+      'kurztext2',
+      'langtext',
+      'matchcode',
+      'ean',
+      'supplierName',
+      'category_name',
+    ];
+    ftsCols = desired.filter((c) => info.some((i) => i.name === c));
+    const placeholders = ftsCols.map(() => '?').join(', ');
+    insertFts = db.prepare(
+      `INSERT INTO articles_fts(rowid, ${ftsCols.join(',')}) VALUES (?, ${placeholders})`,
+    );
+    deleteFts = db.prepare('DELETE FROM articles_fts WHERE rowid = ?');
+  }
 
-  const tx = db.transaction((all: typeof processedRows) => {
-    let processed = 0;
-    const CHUNK = 500;
-    for (let i = 0; i < all.length; i += CHUNK) {
-      if (shouldCancel?.()) break;
-      const part = all.slice(i, i + CHUNK);
-      part.forEach((r, idx) => {
-        try {
-          const was = exists.get(r.articleNumber);
-          stmt.run(r);
-          if (was) summary.updated += 1;
-          else summary.inserted += 1;
-        } catch (e: any) {
-          summary.errors.push({ rowIndex: i + idx, articleNumber: r.articleNumber, message: e.message });
-          summary.skipped += 1;
-        }
-      });
-      processed += part.length;
-      onProgress?.({ processed, total });
-      if (shouldCancel?.()) break;
+  let firstErrorLogged = false;
+  const CHUNK = 200;
+
+  for (let i = 0; i < rows.length; i += CHUNK) {
+    if (shouldCancel?.()) {
+      summary.cancelled = true;
+      break;
     }
-  });
+    const part = rows.slice(i, i + CHUNK);
+    const tx = db.transaction((chunk: ImportRow[], offset: number) => {
+      chunk.forEach((r, idx) => {
+        if (summary.cancelled) return;
+        const row: Partial<ArticleRow> = { articleNumber: r.articleNumber };
+        if ('ean' in r) row.ean = r.ean ?? null;
+        if ('name' in r) row.name = r.name ?? null;
+        if ('price' in r) row.price = r.price ?? null;
+        if ('unit' in r) row.unit = r.unit ?? null;
+        if ('productGroup' in r) row.productGroup = r.productGroup ?? null;
+        let categoryName: string | null = null;
+        if ('category' in r) {
+          const { id, name } = resolveCategory(r.category ?? null);
+          row.category_id = id;
+          categoryName = name;
+        }
 
-  tx(processedRows);
+        const { sql, params, columns, updateCols } = buildUpsertForRow(row);
+        if (summary.processed === 0) {
+          console.debug('[import] cols', columns, 'updateCols', updateCols);
+        }
+        const stmt = db.prepare(sql);
+        try {
+          const existing = existsStmt.get(r.articleNumber) as { rowid: number } | undefined;
+          const res = stmt.run(params);
+          const rowid = existing?.rowid ?? Number(res.lastInsertRowid);
+          if (existing) summary.updated += 1;
+          else summary.inserted += 1;
+
+          if (useFTSDirectWrite && insertFts && deleteFts) {
+            deleteFts.run(rowid);
+            const vals = ftsCols.map((c) => {
+              switch (c) {
+                case 'articleNumber':
+                  return r.articleNumber;
+                case 'name':
+                  return row.name ?? '';
+                case 'kurztext2':
+                  return '';
+                case 'langtext':
+                  return '';
+                case 'matchcode':
+                  return '';
+                case 'ean':
+                  return row.ean ?? '';
+                case 'supplierName':
+                  return '';
+                case 'category_name':
+                  return categoryName ?? '';
+                default:
+                  return '';
+              }
+            });
+            insertFts.run(rowid, ...vals);
+          }
+        } catch (e) {
+          const err = e as Error;
+          summary.errors.push({
+            rowIndex: offset + idx,
+            articleNumber: r.articleNumber,
+            message: err.message,
+          });
+          summary.skipped += 1;
+          if (!firstErrorLogged) {
+            const columnsPresent = Object.keys(row);
+            const valuesPresent = columnsPresent.map((c) => (row as Record<string, unknown>)[c]);
+            console.error('[import] row fail', {
+              row: offset + idx,
+              columnsPresent,
+              valuesPresent,
+              sql,
+              message: err.message,
+            });
+            firstErrorLogged = true;
+          }
+        }
+
+        summary.processed += 1;
+        onProgress?.({ processed: summary.processed, total });
+        if (shouldCancel?.()) summary.cancelled = true;
+      });
+    });
+    tx(part, i);
+    if (summary.cancelled) break;
+  }
 
   return summary;
 }
+

--- a/src/renderer/features/import/StepPreview.tsx
+++ b/src/renderer/features/import/StepPreview.tsx
@@ -86,7 +86,7 @@ const StepPreview: React.FC<Props> = ({ rows, mapping, onBack, onCancel, onCompl
       const res: any = await window.api.import.run({ rows: goodRows });
       if (res?.ok) {
         console.info('Import beendet');
-        onComplete(res.data, res.data.cancelled === true);
+        onComplete(res.data, res.data.cancelled);
       } else {
         console.error('Import fehlgeschlagen', res?.error);
         alert(res?.error?.message || 'Import fehlgeschlagen');

--- a/src/renderer/features/import/types.ts
+++ b/src/renderer/features/import/types.ts
@@ -36,8 +36,10 @@ export type ImportRow = {
 
 export type ImportSummary = {
   total: number;
+  processed: number;
   inserted: number;
   updated: number;
   skipped: number;
   errors: { rowIndex: number; articleNumber?: string; message: string }[];
+  cancelled: boolean;
 };

--- a/src/renderer/features/import/validators.ts
+++ b/src/renderer/features/import/validators.ts
@@ -43,8 +43,6 @@ export function validateRows(rows: RawImportRow[], mapping: Mapping) {
       const name = normalizeString(r.name);
       if (!name) warnings.push('Name fehlt, wird als leer gespeichert');
       row.name = name || null;
-    } else {
-      warnings.push('Name nicht gesetzt (leer gespeichert)');
     }
 
     if (mapping.price !== undefined && mapping.price !== null) {


### PR DESCRIPTION
## Summary
- build dynamic UPSERT statements that only touch mapped article fields
- validate import rows only for mapped columns and extend import summary
- track progress, collect per-row errors and write FTS entries during import

## Testing
- `npm test` *(fails: Fehlende lokale Node-Header/Lib)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b9e7170cb88325b527ed8a79786a77