### PR TITLE
feat: add flexible article import

### DIFF
--- a/src/main/importer.ts
+++ b/src/main/importer.ts
@@ -1,0 +1,196 @@
+import Database from 'better-sqlite3';
+
+export type ImportMapping = Partial<{
+  articleNumber: string;
+  ean: string;
+  name: string;
+  price: string;
+  unit: string;
+  productGroup: string;
+  categoryName: string;
+}>;
+
+export type ImportOptions = {
+  createMissingCategories?: boolean;
+  dryRun?: boolean;
+};
+
+export type ImportRequest = {
+  rows: Record<string, unknown>[];
+  mapping: ImportMapping;
+  options?: ImportOptions;
+};
+
+export type ImportResult = {
+  ok: number;
+  inserted: number;
+  updated: number;
+  skipped: number;
+  errors: Array<{
+    row: number;
+    reason: string;
+    raw: Record<string, unknown>;
+    mapped: Record<string, unknown>;
+  }>;
+  errorCsv?: string;
+};
+
+export function runArticleImport(db: Database, req: ImportRequest): ImportResult {
+  const { rows, mapping, options } = req;
+  const opts = { createMissingCategories: false, dryRun: false, ...(options ?? {}) };
+
+  const result: ImportResult = { ok: 0, inserted: 0, updated: 0, skipped: 0, errors: [] };
+
+  const trim = (v: unknown) => (typeof v === 'string' ? v.trim() : v);
+  const toNull = (v: unknown) => {
+    if (v === undefined || v === null) return null;
+    if (typeof v === 'string' && v.trim() === '') return null;
+    return v;
+  };
+  const toPrice = (v: unknown): number | null => {
+    if (v === undefined || v === null) return null;
+    if (typeof v === 'number') return Number.isFinite(v) ? v : null;
+    if (typeof v === 'string') {
+      const s = v.replace(/\./g, '').replace(',', '.').trim();
+      const n = Number(s);
+      return Number.isFinite(n) ? n : null;
+    }
+    return null;
+  };
+
+  const get = (row: Record<string, unknown>, header?: string) =>
+    header ? toNull(trim(row[header])) : null;
+
+  const selectArticleId = db.prepare(`SELECT id FROM articles WHERE articleNumber = ?`);
+  const insertArticleStmtBase = db.prepare(`
+    INSERT INTO articles (articleNumber, name, price, unit, ean, productGroup, category_id, updated_at)
+    VALUES (@articleNumber, @name, COALESCE(@price, 0), @unit, @ean, @productGroup, @category_id, CURRENT_TIMESTAMP)
+  `);
+  const updateArticleStmtFactory = (cols: string[]) =>
+    db.prepare(`
+      UPDATE articles
+      SET ${cols.map((c) => `${c}=@${c}`).join(', ')}, updated_at=CURRENT_TIMESTAMP
+      WHERE articleNumber=@articleNumber
+    `);
+
+  const ensureCategoryId = (name: string | null): number | null => {
+    if (!name) return null;
+    const row = db.prepare(`SELECT id FROM categories WHERE name = ?`).get(String(name)) as { id: number } | undefined;
+    if (row?.id) return row.id;
+    if (!opts.createMissingCategories) return null;
+    const info = db.prepare(`INSERT INTO categories (name) VALUES (?)`).run(String(name));
+    return Number(info.lastInsertRowid);
+  };
+
+  const trx = db.transaction((rowsIn: typeof rows) => {
+    for (let i = 0; i < rowsIn.length; i++) {
+      const raw = rowsIn[i] ?? {};
+      const mapped: Record<string, unknown> = {};
+
+      try {
+        db.exec('SAVEPOINT one');
+
+        const articleNumber = String(get(raw, mapping.articleNumber) ?? '').trim();
+        if (!articleNumber) {
+          result.errors.push({ row: i, reason: 'Pflichtfeld "Artikelnummer" fehlt', raw, mapped: {} });
+          db.exec('RELEASE one');
+          continue;
+        }
+        mapped.articleNumber = articleNumber;
+
+        const name = get(raw, mapping.name) as string | null;
+        const ean = get(raw, mapping.ean) as string | null;
+        const unit = get(raw, mapping.unit) as string | null;
+        const productGroup = get(raw, mapping.productGroup) as string | null;
+        const price = toPrice(get(raw, mapping.price) as string | number | null);
+        const categoryName = get(raw, mapping.categoryName) as string | null;
+
+        if (name !== null) mapped.name = name;
+        if (ean !== null) mapped.ean = ean;
+        if (unit !== null) mapped.unit = unit;
+        if (productGroup !== null) mapped.productGroup = productGroup;
+        if (price !== null) mapped.price = price;
+
+        const category_id = categoryName !== null ? ensureCategoryId(categoryName) : null;
+        if (categoryName !== null) mapped.category_id = category_id;
+
+        const existing = selectArticleId.get(articleNumber) as { id: number } | undefined;
+
+        if (existing) {
+          const updatable = ['name', 'price', 'unit', 'ean', 'productGroup', 'category_id'].filter((k) => k in mapped);
+
+          if (updatable.length === 0) {
+            result.skipped++;
+            db.exec('RELEASE one');
+            continue;
+          }
+
+          const stmt = updateArticleStmtFactory(updatable);
+          if (!opts.dryRun) stmt.run({ articleNumber, ...mapped });
+          result.updated++;
+          db.exec('RELEASE one');
+          continue;
+        }
+
+        if (!name || String(name).trim() === '') {
+          result.errors.push({
+            row: i,
+            reason: 'Neu anlegen nicht möglich: "Name" fehlt (Pflichtfeld für INSERT).',
+            raw,
+            mapped: { articleNumber, ...mapped },
+          });
+          db.exec('RELEASE one');
+          continue;
+        }
+
+        const insertPayload = {
+          articleNumber,
+          name: String(name),
+          price: price ?? 0,
+          unit: unit ?? null,
+          ean: ean ?? null,
+          productGroup: productGroup ?? null,
+          category_id: category_id ?? null,
+        };
+
+        if (!opts.dryRun) insertArticleStmtBase.run(insertPayload);
+        result.inserted++;
+        db.exec('RELEASE one');
+      } catch (e: any) {
+        db.exec('ROLLBACK TO one');
+        result.errors.push({
+          row: i,
+          reason: e?.message || 'Unbekannter Fehler (SQL)',
+          raw,
+          mapped,
+        });
+        db.exec('RELEASE one');
+      }
+    }
+  });
+
+  trx(rows);
+
+  result.ok = result.inserted + result.updated;
+
+  if (result.errors.length > 0) {
+    const records = result.errors.map((e) => ({
+      row: e.row,
+      reason: e.reason,
+      articleNumber: (e.mapped?.articleNumber as string) ?? '',
+      mappedJson: JSON.stringify(e.mapped ?? {}),
+      rawJson: JSON.stringify(e.raw ?? {}),
+    }));
+    const header = 'row;reason;articleNumber;mappedJson;rawJson';
+    const body = records
+      .map((r) =>
+        [r.row, r.reason, r.articleNumber, r.mappedJson, r.rawJson]
+          .map((s) => `"${String(s).replace(/"/g, '""')}"`)
+          .join(';'),
+      )
+      .join('\n');
+    result.errorCsv = `${header}\n${body}`;
+  }
+
+  return result;
+}

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -13,6 +13,7 @@ import {
   createCategory,
   renameCategory,
   deleteCategory,
+  db,
 } from '../db';
 import { IPC_CHANNELS, ok, err } from '../../shared/ipc';
 import { registerCartHandlers } from './cart';
@@ -21,6 +22,7 @@ import { registerShellHandlers } from './shell';
 import { registerMediaHandlers } from './media';
 import { registerArticlesHandlers } from './articles';
 import { registerImportHandlers } from './import';
+import { runArticleImport } from '../importer';
 
 export function registerIpcHandlers() {
   registerCartHandlers();
@@ -37,6 +39,19 @@ export function registerIpcHandlers() {
   ipcMain.handle(IPC_CHANNELS.datanorm.import, async (_e, { filePath, mapping, categoryId }) => {
     const res = await importDatanormFile({ filePath, mapping, categoryId });
     console.log('Import result', res);
+    return res;
+  });
+
+  ipcMain.handle('import:run', (_evt, payload) => {
+    console.log('[import] payload.mapping =', payload?.mapping);
+    const res = runArticleImport(db, payload);
+    console.log('[import] result =', {
+      ok: res.ok,
+      inserted: res.inserted,
+      updated: res.updated,
+      skipped: res.skipped,
+      errors: res.errors.length,
+    });
     return res;
   });
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -93,6 +93,7 @@ const api = {
     },
     cancel: () => ipcRenderer.invoke(IPC_CHANNELS.import.cancel),
   },
+  invoke: (channel: string, payload?: any) => ipcRenderer.invoke(channel, payload),
   openDevTools: () => ipcRenderer.invoke(IPC_CHANNELS.devtools.open),
 };
 

--- a/src/renderer/features/import/ImportWizard.tsx
+++ b/src/renderer/features/import/ImportWizard.tsx
@@ -3,14 +3,13 @@ import StepFile from './StepFile';
 import StepMapping from './StepMapping';
 import StepPreview from './StepPreview';
 import StepResult from './StepResult';
-import type { ParsedFile, Mapping, PreviewRow, ImportResult } from './types';
+import type { ParsedFile, Mapping, ImportResult } from './types';
 
 type Props = { open: boolean; onClose: () => void };
 
 const ImportWizard: React.FC<Props> = ({ open, onClose }) => {
   const [step, setStep] = useState(0);
   const [parsed, setParsed] = useState<ParsedFile | null>(null);
-  const [rows, setRows] = useState<PreviewRow[]>([]);
   const [mapping, setMapping] = useState<Mapping>({});
   const [result, setResult] = useState<ImportResult | null>(null);
 
@@ -21,8 +20,7 @@ const ImportWizard: React.FC<Props> = ({ open, onClose }) => {
     setStep(1);
   };
 
-    const handleMapped = (r: PreviewRow[], m: Mapping) => {
-    setRows(r);
+  const handleMapped = (m: Mapping) => {
     setMapping(m);
     setStep(2);
   };
@@ -30,7 +28,6 @@ const ImportWizard: React.FC<Props> = ({ open, onClose }) => {
   const reset = () => {
     setStep(0);
     setParsed(null);
-    setRows([]);
     setMapping({});
     setResult(null);
   };
@@ -38,6 +35,11 @@ const ImportWizard: React.FC<Props> = ({ open, onClose }) => {
   const handleCancel = () => {
     reset();
     onClose();
+  };
+
+  const handleFinish = () => {
+    window.dispatchEvent(new Event('articles:refresh'));
+    handleCancel();
   };
 
   const handleComplete = (res: ImportResult) => {
@@ -52,27 +54,27 @@ const ImportWizard: React.FC<Props> = ({ open, onClose }) => {
         {step === 1 && parsed && (
           <StepMapping
             headers={parsed.headers}
-            rows={parsed.rows}
             onBack={() => setStep(0)}
             onMapped={handleMapped}
           />
         )}
-        {step === 2 && (
+        {step === 2 && parsed && (
           <StepPreview
-            rows={rows}
+            headers={parsed.headers}
+            rows={parsed.rows}
             mapping={mapping}
             onBack={() => setStep(1)}
-            onCancel={handleCancel}
             onComplete={handleComplete}
           />
         )}
         {step === 3 && result && (
           <StepResult
             result={result}
-            onClose={handleCancel}
+            onClose={handleFinish}
             onRestart={() => {
-              reset();
-              setStep(0);
+              setResult(null);
+              setMapping({});
+              setStep(1);
             }}
           />
         )}

--- a/src/renderer/features/import/StepMapping.tsx
+++ b/src/renderer/features/import/StepMapping.tsx
@@ -1,11 +1,10 @@
 import React, { useState } from 'react';
-import type { Mapping, PreviewRow, MappingField } from './types';
+import type { Mapping, MappingField } from './types';
 
 type Props = {
   headers: string[];
-  rows: unknown[][];
   onBack: () => void;
-  onMapped: (rows: PreviewRow[], mapping: Mapping) => void;
+  onMapped: (mapping: Mapping) => void;
 };
 
 const targetFields: { key: MappingField; label: string }[] = [
@@ -15,24 +14,14 @@ const targetFields: { key: MappingField; label: string }[] = [
   { key: 'price', label: 'Preis' },
   { key: 'unit', label: 'Einheit' },
   { key: 'productGroup', label: 'Produktgruppe' },
-  { key: 'category', label: 'Kategorie' },
+  { key: 'categoryName', label: 'Kategorie' },
 ];
 
-const StepMapping: React.FC<Props> = ({ headers, rows, onBack, onMapped }) => {
+const StepMapping: React.FC<Props> = ({ headers, onBack, onMapped }) => {
   const [mapping, setMapping] = useState<Mapping>({});
 
   const apply = () => {
-    const idx: Record<string, number> = {};
-    headers.forEach((h, i) => (idx[h] = i));
-    const mapped: PreviewRow[] = rows.map((r) => {
-      const obj: PreviewRow = {};
-      (Object.keys(mapping) as MappingField[]).forEach((key) => {
-        const col = mapping[key];
-        if (col) obj[key] = r[idx[col]];
-      });
-      return obj;
-    });
-    onMapped(mapped, mapping);
+    onMapped(mapping);
   };
 
   return (
@@ -68,7 +57,9 @@ const StepMapping: React.FC<Props> = ({ headers, rows, onBack, onMapped }) => {
         </tbody>
       </table>
       <div className="modal-actions">
-        <button onClick={onBack}>Zurück</button>
+        <button onClick={onBack} disabled aria-disabled="true">
+          Zurück
+        </button>
         <button
           className="primary"
           onClick={apply}

--- a/src/renderer/features/import/StepResult.tsx
+++ b/src/renderer/features/import/StepResult.tsx
@@ -8,7 +8,18 @@ interface Props {
 }
 
 const StepResult: React.FC<Props> = ({ result, onClose, onRestart }) => {
-  const { ok, inserted, updated, skipped, errors } = result;
+  const { ok, inserted, updated, skipped, errors, errorCsv } = result;
+
+  const downloadErrors = () => {
+    if (!errorCsv) return;
+    const blob = new Blob([errorCsv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'import-errors.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
 
   return (
     <div>
@@ -24,12 +35,15 @@ const StepResult: React.FC<Props> = ({ result, onClose, onRestart }) => {
           <summary>Fehler anzeigen</summary>
           <ul>
             {errors.map((e) => (
-              <li key={e.row}>Zeile {e.row + 1}: {e.message}</li>
+              <li key={e.row}>Zeile {e.row + 1}: {e.reason}</li>
             ))}
           </ul>
         </details>
       )}
       <div className="wizard-footer" role="toolbar">
+        <button onClick={downloadErrors} disabled={!errorCsv} aria-disabled={!errorCsv}>
+          Fehler als CSV herunterladen
+        </button>
         <button onClick={onRestart}>Erneut importieren</button>
         <button className="primary" onClick={onClose}>
           Fertig

--- a/src/renderer/features/import/types.ts
+++ b/src/renderer/features/import/types.ts
@@ -10,7 +10,7 @@ export type MappingField =
   | 'price'
   | 'unit'
   | 'productGroup'
-  | 'category';
+  | 'categoryName';
 
 // maps target fields to column names from the source file
 export type Mapping = Partial<Record<MappingField, string>>;
@@ -23,5 +23,11 @@ export type ImportResult = {
   inserted: number;
   updated: number;
   skipped: number;
-  errors: { row: number; message: string }[];
+  errors: Array<{
+    row: number;
+    reason: string;
+    raw: Record<string, unknown>;
+    mapped: Record<string, unknown>;
+  }>;
+  errorCsv?: string;
 };

--- a/src/renderer/types/global.d.ts
+++ b/src/renderer/types/global.d.ts
@@ -23,6 +23,7 @@ declare global {
         upsertMany: (items: any[]) => Promise<any>;
         import: (payload: { rows: any[] }) => Promise<any>;
       };
+      invoke: (channel: string, payload?: any) => Promise<any>;
     };
   }
 }


### PR DESCRIPTION
## Summary
- add robust `runArticleImport` backend with per-row savepoints and optional category creation
- expose `import:run` IPC channel and generic `window.api.invoke`
- implement CSV/XLSX import wizard allowing partial field mapping and error CSV download

## Testing
- `npm test` *(fails: Fehlende lokale Node-Header/Lib)*

------
https://chatgpt.com/codex/tasks/task_e_68baaae278408325ae8fb4a0bbef4426