### PR TITLE
feat: overhaul article import

### DIFF
--- a/src/main/db.ts
+++ b/src/main/db.ts
@@ -11,10 +11,10 @@ export const dbPath = path.join(dataDir, 'app-data.db');
 console.log('DB path:', dbPath);
 export const db = new Database(dbPath);
 ensureSchema(db);
-console.debug(
-  "[db] index_list('articles') =>",
-  db.prepare("PRAGMA index_list('articles')").all(),
-);
+const ti = db.prepare("PRAGMA table_info(articles)").all();
+console.log('[db] table_info(articles) =>', ti.map(({ name, notnull, type }) => ({ name, notnull, type })));
+const il = db.prepare("PRAGMA index_list('articles')").all();
+console.log("[db] index_list('articles') =>", il);
 console.log('Schema OK');
 
 export const mediaRoot = path.join(app.getPath('userData'), 'media');

--- a/src/main/ipc/articles.ts
+++ b/src/main/ipc/articles.ts
@@ -1,7 +1,8 @@
 import { ipcMain } from 'electron';
 import { z } from 'zod';
-import { searchArticles, upsertArticles, type ArticleRow, type ImportRow } from '../db';
+import { searchArticles, upsertArticles, db, type ArticleRow, type ImportRow } from '../db';
 import { IPC_CHANNELS, SearchPayloadSchema, SearchResultSchema } from '../../shared/ipc';
+import { runImport } from '../importer';
 
 export function registerArticlesHandlers() {
   ipcMain.handle(IPC_CHANNELS.articles.search, (_e, payload) => {
@@ -64,5 +65,9 @@ export function registerArticlesHandlers() {
     } catch (e: any) {
       return { ok: 0, inserted: 0, updated: 0, skipped: 0, errors: [{ row: -1, message: e?.message || String(e) }] };
     }
+  });
+
+  ipcMain.handle('import:run', async (_evt, { rows, mapping }) => {
+    return runImport({ rows, mapping, db });
   });
 }

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -22,7 +22,6 @@ import { registerShellHandlers } from './shell';
 import { registerMediaHandlers } from './media';
 import { registerArticlesHandlers } from './articles';
 import { registerImportHandlers } from './import';
-import { runArticleImport } from '../importer';
 
 export function registerIpcHandlers() {
   registerCartHandlers();
@@ -39,19 +38,6 @@ export function registerIpcHandlers() {
   ipcMain.handle(IPC_CHANNELS.datanorm.import, async (_e, { filePath, mapping, categoryId }) => {
     const res = await importDatanormFile({ filePath, mapping, categoryId });
     console.log('Import result', res);
-    return res;
-  });
-
-  ipcMain.handle('import:run', (_evt, payload) => {
-    console.log('[import] payload.mapping =', payload?.mapping);
-    const res = runArticleImport(db, payload);
-    console.log('[import] result =', {
-      ok: res.ok,
-      inserted: res.inserted,
-      updated: res.updated,
-      skipped: res.skipped,
-      errors: res.errors.length,
-    });
     return res;
   });
 

--- a/src/renderer/features/import/ImportWizard.tsx
+++ b/src/renderer/features/import/ImportWizard.tsx
@@ -73,8 +73,7 @@ const ImportWizard: React.FC<Props> = ({ open, onClose }) => {
             onClose={handleFinish}
             onRestart={() => {
               setResult(null);
-              setMapping({});
-              setStep(1);
+              setStep(2);
             }}
           />
         )}

--- a/src/renderer/features/import/StepMapping.tsx
+++ b/src/renderer/features/import/StepMapping.tsx
@@ -14,7 +14,7 @@ const targetFields: { key: MappingField; label: string }[] = [
   { key: 'price', label: 'Preis' },
   { key: 'unit', label: 'Einheit' },
   { key: 'productGroup', label: 'Produktgruppe' },
-  { key: 'categoryName', label: 'Kategorie' },
+  { key: 'category_id', label: 'Kategorie-ID' },
 ];
 
 const StepMapping: React.FC<Props> = ({ headers, onBack, onMapped }) => {

--- a/src/renderer/features/import/StepPreview.tsx
+++ b/src/renderer/features/import/StepPreview.tsx
@@ -11,7 +11,6 @@ interface Props {
 
 const StepPreview: React.FC<Props> = ({ headers, rows, mapping, onBack, onComplete }) => {
   const [isImporting, setImporting] = useState(false);
-  const [createMissingCategories, setCreateMissingCategories] = useState(true);
 
   const mappedSample = useMemo(() => {
     const idx: Record<string, number> = {};
@@ -41,7 +40,6 @@ const StepPreview: React.FC<Props> = ({ headers, rows, mapping, onBack, onComple
       const res: ImportResult = await window.api.invoke('import:run', {
         rows: objects,
         mapping,
-        options: { createMissingCategories, dryRun: false },
       });
       onComplete(res);
     } catch (e: any) {
@@ -74,14 +72,6 @@ const StepPreview: React.FC<Props> = ({ headers, rows, mapping, onBack, onComple
           </tbody>
         </table>
       </div>
-      <label style={{ display: 'block', marginTop: 8 }}>
-        <input
-          type="checkbox"
-          checked={createMissingCategories}
-          onChange={(e) => setCreateMissingCategories(e.target.checked)}
-        />
-        Fehlende Kategorien anlegen
-      </label>
       <div className="wizard-footer" role="toolbar">
         <button onClick={onBack} disabled={isImporting} aria-disabled={isImporting}>
           Zurück

--- a/src/renderer/features/import/StepResult.tsx
+++ b/src/renderer/features/import/StepResult.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import type { ImportResult } from './types';
 
 interface Props {
@@ -8,7 +8,17 @@ interface Props {
 }
 
 const StepResult: React.FC<Props> = ({ result, onClose, onRestart }) => {
-  const { ok, inserted, updated, skipped, errors, errorCsv } = result;
+  const { ok, inserted, updated, skipped, errors, errorRows } = result;
+
+  const errorCsv = useMemo(() => {
+    if (!errorRows || errorRows.length === 0) return null;
+    const headers = Array.from(new Set(errorRows.flatMap((r) => Object.keys(r))));
+    const lines = [headers.join(';')];
+    for (const r of errorRows) {
+      lines.push(headers.map((h) => JSON.stringify(r[h] ?? '')).join(';'));
+    }
+    return lines.join('\n');
+  }, [errorRows]);
 
   const downloadErrors = () => {
     if (!errorCsv) return;
@@ -28,14 +38,14 @@ const StepResult: React.FC<Props> = ({ result, onClose, onRestart }) => {
         <div className="badge">Inserted: {inserted}</div>
         <div className="badge">Updated: {updated}</div>
         <div className="badge">Skipped: {skipped}</div>
-        <div className="badge">Errors: {errors.length}</div>
+        <div className="badge">Errors: {errors}</div>
       </div>
-      {errors.length > 0 && (
+      {errorRows.length > 0 && (
         <details>
           <summary>Fehler anzeigen</summary>
           <ul>
-            {errors.map((e) => (
-              <li key={e.row}>Zeile {e.row + 1}: {e.reason}</li>
+            {errorRows.map((e) => (
+              <li key={e.row}>Zeile {e.row + 1}: {e.message}</li>
             ))}
           </ul>
         </details>

--- a/src/renderer/features/import/types.ts
+++ b/src/renderer/features/import/types.ts
@@ -10,7 +10,7 @@ export type MappingField =
   | 'price'
   | 'unit'
   | 'productGroup'
-  | 'categoryName';
+  | 'category_id';
 
 // maps target fields to column names from the source file
 export type Mapping = Partial<Record<MappingField, string>>;
@@ -23,11 +23,7 @@ export type ImportResult = {
   inserted: number;
   updated: number;
   skipped: number;
-  errors: Array<{
-    row: number;
-    reason: string;
-    raw: Record<string, unknown>;
-    mapped: Record<string, unknown>;
-  }>;
-  errorCsv?: string;
+  errors: number;
+  errorRows: Array<{ row: number; message: string; [key: string]: any }>;
+  fatal?: string;
 };


### PR DESCRIPTION
## Summary
- add central importer with dynamic COALESCE upsert and fallback update/insert
- expose `import:run` IPC and log article table info/indexes
- refine import wizard UI and result view with error CSV download

## Testing
- `npm test` *(fails: Fehlende lokale Node-Header/Lib)*

------
https://chatgpt.com/codex/tasks/task_e_68bab42b57d88325bc8d212f82a530ea