### PR TITLE
Improve article import error reporting

### DIFF
--- a/src/main/datanorm/parser.ts
+++ b/src/main/datanorm/parser.ts
@@ -110,5 +110,5 @@ export async function importDatanormFile({
 
   const res = upsertArticles(arr);
   const durationMs = Date.now() - start;
-  return { parsed: arr.length, inserted: res.count, updated: 0, durationMs };
+  return { parsed: arr.length, inserted: res.inserted, updated: res.updated, durationMs };
 }

--- a/src/main/ipc/articles.ts
+++ b/src/main/ipc/articles.ts
@@ -1,8 +1,7 @@
 import { ipcMain } from 'electron';
 import { z } from 'zod';
-import { searchArticles, upsertArticles, db, type ArticleRow, type ImportRow } from '../db';
+import { searchArticles, upsertArticles, type ArticleRow, type ImportRow } from '../db';
 import { IPC_CHANNELS, SearchPayloadSchema, SearchResultSchema } from '../../shared/ipc';
-import { runImport } from '../importer';
 
 export function registerArticlesHandlers() {
   ipcMain.handle(IPC_CHANNELS.articles.search, (_e, payload) => {
@@ -29,45 +28,44 @@ export function registerArticlesHandlers() {
   ipcMain.handle(IPC_CHANNELS.articles.upsertMany, (_e, items) => {
     try {
       const parsed = UpsertMany.parse(items) as ArticleRow[];
-      const res = upsertArticles(parsed);
-      const inserted = res.filter((r: any) => r.status === 'inserted').length;
-      const updated = res.filter((r: any) => r.status === 'updated').length;
-      return { ok: true, inserted, updated };
-    } catch (err: any) {
-      console.error('articles:upsertMany failed', err);
-      if (err instanceof z.ZodError) {
-        return { ok: false, error: { message: err.message, details: err.issues } };
-      }
+      return upsertArticles(parsed);
+    } catch (e: any) {
       return {
-        ok: false,
-        error: {
-          message: err?.message || 'UPSERT failed',
-          row: err?.row,
-          articleNumber: err?.articleNumber,
-        },
+        ok: 0,
+        inserted: 0,
+        updated: 0,
+        skipped: 0,
+        errors: [
+          {
+            row: -1,
+            message: String(e?.message || e),
+            sql: '',
+            params: {},
+          },
+        ],
       };
     }
   });
 
   ipcMain.handle(IPC_CHANNELS.articles.import, async (_evt, payload: { rows: ImportRow[] }) => {
     try {
-      const results = upsertArticles(payload.rows);
-      const inserted = results.filter((r: any) => r.status === 'inserted').length;
-      const updated = results.filter((r: any) => r.status === 'updated').length;
-      const errors = results.filter((r: any) => r.status === 'error');
-      return {
-        ok: results.length - inserted - updated - errors.length,
-        inserted,
-        updated,
-        skipped: 0,
-        errors,
-      };
+      const res = upsertArticles(payload.rows);
+      return res;
     } catch (e: any) {
-      return { ok: 0, inserted: 0, updated: 0, skipped: 0, errors: [{ row: -1, message: e?.message || String(e) }] };
+      return {
+        ok: 0,
+        inserted: 0,
+        updated: 0,
+        skipped: 0,
+        errors: [
+          {
+            row: -1,
+            message: String(e?.message || e),
+            sql: '',
+            params: {},
+          },
+        ],
+      };
     }
-  });
-
-  ipcMain.handle('import:run', async (_evt, { rows, mapping }) => {
-    return runImport({ rows, mapping, db });
   });
 }

--- a/src/renderer/features/import/StepPreview.tsx
+++ b/src/renderer/features/import/StepPreview.tsx
@@ -30,16 +30,18 @@ const StepPreview: React.FC<Props> = ({ headers, rows, mapping, onBack, onComple
   async function startImport() {
     setImporting(true);
     try {
-      const objects = rows.map((r) => {
-        const obj: Record<string, unknown> = {};
-        headers.forEach((h, i) => {
-          obj[h] = r[i];
+      const idx: Record<string, number> = {};
+      headers.forEach((h, i) => (idx[h] = i));
+      const objects = rows.map((r, rowIdx) => {
+        const obj: Record<string, unknown> = { row: rowIdx };
+        (Object.keys(mapping) as MappingField[]).forEach((key) => {
+          const col = mapping[key];
+          if (col) obj[key] = r[idx[col]];
         });
         return obj;
       });
-      const res: ImportResult = await window.api.invoke('import:run', {
+      const res: ImportResult = await window.api.invoke('articles:import', {
         rows: objects,
-        mapping,
       });
       onComplete(res);
     } catch (e: any) {

--- a/src/renderer/features/import/StepResult.tsx
+++ b/src/renderer/features/import/StepResult.tsx
@@ -8,17 +8,18 @@ interface Props {
 }
 
 const StepResult: React.FC<Props> = ({ result, onClose, onRestart }) => {
-  const { ok, inserted, updated, skipped, errors, errorRows } = result;
+  const { ok, inserted, updated, skipped, errors } = result;
 
   const errorCsv = useMemo(() => {
-    if (!errorRows || errorRows.length === 0) return null;
-    const headers = Array.from(new Set(errorRows.flatMap((r) => Object.keys(r))));
-    const lines = [headers.join(';')];
-    for (const r of errorRows) {
-      lines.push(headers.map((h) => JSON.stringify(r[h] ?? '')).join(';'));
+    if (!errors || errors.length === 0) return null;
+    const lines = ['row;code;message;sql;params'];
+    for (const e of errors) {
+      lines.push(
+        `${e.row};${e.code ?? ''};"${e.message.replaceAll('"', '""')}";"${e.sql.replaceAll('"', '""')}";"${JSON.stringify(e.params).replaceAll('"', '""')}"`
+      );
     }
     return lines.join('\n');
-  }, [errorRows]);
+  }, [errors]);
 
   const downloadErrors = () => {
     if (!errorCsv) return;
@@ -38,14 +39,16 @@ const StepResult: React.FC<Props> = ({ result, onClose, onRestart }) => {
         <div className="badge">Inserted: {inserted}</div>
         <div className="badge">Updated: {updated}</div>
         <div className="badge">Skipped: {skipped}</div>
-        <div className="badge">Errors: {errors}</div>
+        <div className="badge">Errors: {errors.length}</div>
       </div>
-      {errorRows.length > 0 && (
+      {errors.length > 0 && (
         <details>
           <summary>Fehler anzeigen</summary>
           <ul>
-            {errorRows.map((e) => (
-              <li key={e.row}>Zeile {e.row + 1}: {e.message}</li>
+            {errors.map((e) => (
+              <li key={e.row}>
+                row={e.row}; sql={e.sql}; params={JSON.stringify(e.params)}; code={e.code ?? ''}; message={e.message}
+              </li>
             ))}
           </ul>
         </details>

--- a/src/renderer/features/import/types.ts
+++ b/src/renderer/features/import/types.ts
@@ -18,12 +18,19 @@ export type Mapping = Partial<Record<MappingField, string>>;
 // row object limited to the mapped target fields
 export type PreviewRow = Record<string, unknown>;
 
+export type ImportError = {
+  row: number;
+  code?: number;
+  message: string;
+  sql: string;
+  params: Record<string, any>;
+};
+
 export type ImportResult = {
   ok: number;
   inserted: number;
   updated: number;
   skipped: number;
-  errors: number;
-  errorRows: Array<{ row: number; message: string; [key: string]: any }>;
+  errors: ImportError[];
   fatal?: string;
 };

--- a/tests/upsertArticles.spec.ts
+++ b/tests/upsertArticles.spec.ts
@@ -23,14 +23,10 @@ describe('upsertArticles', () => {
       ean: null,
     }));
     const res1 = upsertArticles(batch);
-    const ins1 = res1.filter((r) => r.status === 'inserted').length;
-    const upd1 = res1.filter((r) => r.status === 'updated').length;
-    expect(ins1 + upd1).toBe(53);
+    expect(res1.inserted + res1.updated).toBe(53);
     const res2 = upsertArticles(batch);
-    const ins2 = res2.filter((r) => r.status === 'inserted').length;
-    const upd2 = res2.filter((r) => r.status === 'updated').length;
-    expect(ins2).toBe(0);
-    expect(upd2).toBe(53);
+    expect(res2.inserted).toBe(0);
+    expect(res2.updated).toBe(53);
   });
 });
 


### PR DESCRIPTION
## Summary
- Ensure article imports always update `updated_at` by building safe UPSERT statements
- Return detailed SQL error information from main process IPC handlers
- Display import errors with SQL and parameters and allow CSV export in the wizard

## Testing
- `npm test` *(fails: Fehlende lokale Node-Header/Lib)*
- `npm run build:preload`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68bad66ab4d483258e03d00b7493b7b2